### PR TITLE
fix(ci): P0 perf 测试使用预配置 agent 替代动态创建

### DIFF
--- a/.github/workflows/release-gates.yml
+++ b/.github/workflows/release-gates.yml
@@ -33,6 +33,7 @@ jobs:
       RUN_TENANT_REGRESSION: "1"
       PERF_SAMPLES: "6"
       PERF_POLL_MAX: "90"
+      PERF_AGENT_ID: "conversation"
       DRILL_POLL_MAX: "90"
       DRILL_POLL_INTERVAL: "2"
     steps:

--- a/scripts/release-p0-perf.sh
+++ b/scripts/release-p0-perf.sh
@@ -6,6 +6,9 @@ AUTH_HEADER="${CORAG_AUTH_HEADER:-}"
 AUTO_LOGIN="${CORAG_AUTO_LOGIN:-1}"
 LOGIN_USERNAME="${CORAG_LOGIN_USERNAME:-admin}"
 LOGIN_PASSWORD="${CORAG_LOGIN_PASSWORD:-admin}"
+# Agent ID to use for perf tests. Agents are now pre-configured in configs/agents.yaml;
+# dynamic creation via POST /api/agents is no longer supported.
+PERF_AGENT_ID="${PERF_AGENT_ID:-conversation}"
 PERF_SAMPLES="${PERF_SAMPLES:-20}"
 PERF_POLL_MAX="${PERF_POLL_MAX:-90}"
 PERF_POLL_INTERVAL="${PERF_POLL_INTERVAL:-2}"
@@ -160,22 +163,8 @@ main() {
     exit 1
   fi
 
-  local agent_name="perf-agent-$ts"
-  echo "[perf] creating agent: $agent_name"
-  http_request POST "$API_URL/api/agents" "{\"name\":\"$agent_name\"}"
-  if [[ "$RESPONSE_CODE" != "200" ]]; then
-    echo "[perf] create agent failed: HTTP $RESPONSE_CODE" >&2
-    echo "$RESPONSE_BODY" >&2
-    exit 1
-  fi
-
-  local agent_id
-  agent_id="$(json_get "id" "$RESPONSE_BODY")"
-  if [[ -z "$agent_id" ]]; then
-    echo "[perf] create agent failed: missing id" >&2
-    echo "$RESPONSE_BODY" >&2
-    exit 1
-  fi
+  echo "[perf] using pre-configured agent: $PERF_AGENT_ID"
+  local agent_id="$PERF_AGENT_ID"
 
   local started_at
   started_at="$(date +%s)"


### PR DESCRIPTION
## 问题

Release Gates 的 P0 performance gate 失败：

```
[perf] create agent failed: HTTP 404
Not Found
```

## 根本原因

`POST /api/agents` 已在 2.0 架构中移除，agent 现在通过 `configs/agents.yaml` 在启动时预配置加载，不再支持动态远程创建。但 `release-p0-perf.sh` 仍在尝试动态创建临时 agent。

## 修复

- `scripts/release-p0-perf.sh`：移除动态创建逻辑，改为使用 `PERF_AGENT_ID` 环境变量（默认值 `conversation`，已在 `configs/agents.yaml` 中预定义）
- `.github/workflows/release-gates.yml`：添加 `PERF_AGENT_ID=conversation`