### PR TITLE
docs: add Copilot review instructions for Aetheris runtime semantics

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -50,6 +50,7 @@ Focus reviews on these invariants first:
 Prioritize comments when PRs change runtime, scheduler, storage, checkpoint, replay, effect, or recovery logic without adequate tests.
 
 Encourage tests for:
+
 - crash recovery
 - duplicate delivery / duplicate execution prevention
 - replay determinism
@@ -68,6 +69,7 @@ Encourage tests for:
 ## Key directories
 
 Focus extra attention on changes in these directories:
+
 - `internal/agent/runtime/` - Core execution engine
 - `internal/agent/runtime/job/` - Event-sourced job management
 - `internal/agent/runtime/runner/` - Step-level execution with checkpointing


### PR DESCRIPTION
## Summary
- Add `.github/copilot-instructions.md` with Aetheris-specific review rules for Copilot automatic review
- Focus Copilot review on runtime semantics: at-most-once effects, event-sourcing, checkpoint recovery, scheduler fencing, deterministic replay
- Add key directories section to prioritize review attention

## Changes
- New file: `.github/copilot-instructions.md` (3.7KB, under 4KB limit)

## Test plan
- [ ] Verify Copilot uses the new instructions for future PRs
- [ ] Check that instructions file is within 4KB GitHub limit

Made with [Cursor](https://cursor.com)