### PR TITLE
Feat/compliance-evidence-system

### DIFF
--- a/docs/plans/2026-03-20-compliance-evidence-system.md
+++ b/docs/plans/2026-03-20-compliance-evidence-system.md
@@ -1,0 +1,858 @@
+# Compliance Evidence System Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build a production-ready Compliance Evidence System with signed evidence packages, policy-driven automated collection, Forensics API, semantic verification, and evidence lifecycle management.
+
+**Architecture:** The system builds on the existing `pkg/proof/` package which already provides ZIP-based evidence export with hash chain validation. New work adds: (1) Ed25519 digital signatures on evidence packages, (2) a compliance policy engine that auto-triggers exports based on job characteristics, (3) a Forensics API for querying evidence, (4) semantic verification to detect "claimed success but actually failed" fraud, and (5) evidence retention/lifecycle management. All evidence operations are scoped to the current tenant.
+
+**Tech Stack:** Go 1.25, Ed25519 (golang.org/x/crypto/ed25519), archive/zip, PostgreSQL (existing jobstore), Viper for config.
+
+---
+
+## Task 1: Add Digital Signatures to Evidence Packages
+
+**Files:**
+
+- Modify: `pkg/proof/types.go:46-53` — add Signature fields to ProofSummary
+- Modify: `pkg/proof/export.go:27-154` — sign evidence package during export
+- Create: `pkg/proof/signature.go` — Ed25519 signing and verification logic
+- Create: `pkg/proof/signature_test.go`
+- Modify: `pkg/proof/export_test.go` — add signature test
+- Modify: `pkg/proof/verify.go:26-152` — verify signature during verification
+
+**Step 1: Add signature types**
+
+Modify `pkg/proof/types.go` to extend `ProofSummary` and add signing configuration:
+
+```go
+// SigningConfig contains Ed25519 private key for signing evidence packages.
+type SigningConfig struct {
+    PrivateKey ed25519.PrivateKey // loaded from config/env
+}
+
+// SignedProof extends ProofSummary with cryptographic signature.
+type SignedProof struct {
+    ProofSummary
+    Signature     string `json:"signature,omitempty"`       // Base64-encoded Ed25519 signature
+    SignedAt      string `json:"signed_at,omitempty"`       // ISO 8601 timestamp
+    SignerKeyID  string `json:"signer_key_id,omitempty"` // Identifier for the signing key
+}
+```
+
+**Step 2: Create signature.go**
+
+```go
+package proof
+
+import (
+    "crypto/ed25519"
+    "encoding/base64"
+    "fmt"
+    "time"
+
+    "golang.org/x/crypto/ed25519"
+)
+
+// SignEvidence signs the evidence package contents and returns a signature.
+func SignEvidence(privateKey ed25519.PrivateKey, manifest Manifest, events []Event, ledger []ToolInvocation) (string, error) {
+    // Build canonical signing payload: manifest JSON + events NDJSON + ledger NDJSON
+    manifestBytes, _ := json.Marshal(manifest)
+    eventsBytes, _ := eventsToNDJSON(events)
+    ledgerBytes, _ := ledgerToNDJSON(ledger)
+
+    payload := append(manifestBytes, eventsBytes...)
+    payload = append(payload, ledgerBytes...)
+
+    sig := ed25519.Sign(privateKey, payload)
+    return base64.StdEncoding.EncodeToString(sig), nil
+}
+
+// VerifySignature verifies an Ed25519 signature against the evidence package contents.
+func VerifySignature(publicKey ed25519.PublicKey, manifest Manifest, events []Event, ledger []ToolInvocation, signature string) error {
+    sigBytes, err := base64.StdEncoding.DecodeString(signature)
+    if err != nil {
+        return fmt.Errorf("invalid signature encoding: %w", err)
+    }
+
+    manifestBytes, _ := json.Marshal(manifest)
+    eventsBytes, _ := eventsToNDJSON(events)
+    ledgerBytes, _ := ledgerToNDJSON(ledger)
+
+    payload := append(manifestBytes, eventsBytes...)
+    payload = append(payload, ledgerBytes...)
+
+    if !ed25519.Verify(publicKey, payload, sigBytes) {
+        return fmt.Errorf("signature verification failed")
+    }
+    return nil
+}
+```
+
+**Step 3: Modify ExportEvidenceZip to sign**
+
+In `pkg/proof/export.go`, after building proofJSON, add:
+
+```go
+var proofBytes []byte
+if opts.SigningConfig != nil && len(opts.SigningConfig.PrivateKey) > 0 {
+    sig, err := SignEvidence(opts.SigningConfig.PrivateKey, manifest, events, toolInvocations)
+    if err != nil {
+        return nil, fmt.Errorf("failed to sign evidence: %w", err)
+    }
+    signedProof := SignedProof{
+        ProofSummary: proofSummary,
+        Signature:    sig,
+        SignedAt:    time.Now().UTC().Format(time.RFC3339),
+        SignerKeyID: opts.SigningConfig.KeyID,
+    }
+    proofBytes, _ = json.MarshalIndent(signedProof, "", "  ")
+} else {
+    proofBytes = proofJSON
+}
+fileHashes["proof.json"] = ComputeFileHash(proofBytes)
+```
+
+Add to `ExportOptions`:
+
+```go
+type ExportOptions struct {
+    // ... existing fields ...
+    SigningConfig *SigningConfig
+}
+```
+
+**Step 4: VerifyEvidenceZip with signature**
+
+In `pkg/proof/verify.go`, after parsing proof.json, add signature verification if present. If `SignedProof` is detected (has Signature field), verify against the same canonical payload.
+
+**Step 5: Add tests**
+
+```go
+func TestSignAndVerifyEvidence(t *testing.T) {
+    publicKey, privateKey, err := ed25519.GenerateKey(nil)
+    if err != nil {
+        t.Fatalf("generate key: %v", err)
+    }
+
+    events := []Event{{ID: "1", JobID: "job_test", Type: "job_created", Hash: "abc"}}
+    ledger := []ToolInvocation{{ID: "inv1", JobID: "job_test", IdempotencyKey: "key1"}}
+    manifest := Manifest{JobID: "job_test", Version: "2.0"}
+
+    sig, err := SignEvidence(privateKey, manifest, events, ledger)
+    if err != nil {
+        t.Fatalf("sign: %v", err)
+    }
+
+    err = VerifySignature(publicKey, manifest, events, ledger, sig)
+    if err != nil {
+        t.Fatalf("verify: %v", err)
+    }
+}
+```
+
+**Step 6: Run tests**
+
+```bash
+go test ./pkg/proof/... -v -run TestSignAndVerifyEvidence
+```
+
+**Step 7: Commit**
+
+```bash
+git add pkg/proof/signature.go pkg/proof/types.go pkg/proof/export.go pkg/proof/verify.go pkg/proof/signature_test.go
+git commit -m "feat(proof): add Ed25519 digital signatures on evidence packages"
+```
+
+---
+
+## Task 2: Integrate Evidence Export into REST API (already exists, verify + add signing config)
+
+**Files:**
+
+- Modify: `internal/api/http/forensics.go:32-77` — wire signing config into evidence export
+- Modify: `configs/api.yaml` — add signing key configuration section
+
+**Step 1: Add signing key to handler**
+
+In `internal/api/http/handler.go`, check if a signing key is configured and pass it to `buildForensicsPackage`. Read the key from environment or config file.
+
+**Step 2: Add config for signing keys**
+
+```bash
+# Add to configs/api.yaml
+evidence:
+  signing:
+    enabled: true
+    key_file: "/path/to/ed25519_private_key.pem"  # or env: ED25519_PRIVATE_KEY
+    key_id: "default-signer"
+```
+
+**Step 3: Run build to verify compilation**
+
+```bash
+go build ./cmd/api
+```
+
+**Step 4: Commit**
+
+```bash
+git add internal/api/http/forensics.go configs/api.yaml
+git commit -m "feat(api): wire Ed25519 signing config into evidence export"
+```
+
+---
+
+## Task 3: Add SHA256 Hash for All Files in ZIP
+
+**Files:**
+
+- Modify: `pkg/proof/export.go:79-84` — compute hashes for all files, not just 3
+- Modify: `pkg/proof/export_test.go` — verify all file hashes in manifest
+
+**Step 1: Modify export.go**
+
+Currently only events.ndjson, ledger.ndjson, and metadata.json are hashed. Add proof.json and manifest.json:
+
+```go
+fileHashes := map[string]string{
+    "manifest.json":  ComputeFileHash(manifestJSON),
+    "events.ndjson":   ComputeFileHash(eventsNDJSON),
+    "ledger.ndjson":  ComputeFileHash(ledgerNDJSON),
+    "proof.json":     ComputeFileHash(proofJSON),
+    "metadata.json":  ComputeFileHash(metadataJSON),
+}
+```
+
+**Step 2: Verify the change**
+
+```bash
+go test ./pkg/proof/... -v -run TestExport
+```
+
+**Step 3: Commit**
+
+```bash
+git add pkg/proof/export.go
+git commit -m "feat(proof): include SHA256 hash for all files in evidence ZIP manifest"
+```
+
+---
+
+## Task 4: Evidence Package Merge for Multi-Job Compliance Reports
+
+**Files:**
+
+- Create: `pkg/proof/merge.go` — merge multiple evidence packages into one
+- Create: `pkg/proof/merge_test.go`
+
+**Step 1: Design merge structure**
+
+A merged evidence package is a ZIP containing multiple `job_XXX.zip` entries plus a `manifest.json` that lists all included jobs and their root hashes.
+
+```go
+// MergedManifest extends the per-job Manifest to cover multiple jobs.
+type MergedManifest struct {
+    Version         string            `json:"version"`
+    MergedAt        time.Time         `json:"merged_at"`
+    JobCount        int               `json:"job_count"`
+    Jobs            []MergedJobEntry  `json:"jobs"`
+    TotalEventCount int               `json:"total_event_count"`
+    OverallRootHash string            `json:"overall_root_hash"` // Hash of all job root hashes
+}
+
+type MergedJobEntry struct {
+    JobID          string `json:"job_id"`
+    RootHash       string `json:"root_hash"`
+    EventCount     int    `json:"event_count"`
+    LedgerCount    int    `json:"ledger_count"`
+    Filename       string `json:"filename"` // inside ZIP
+}
+```
+
+**Step 2: Implement merge.go**
+
+```go
+package proof
+
+import (
+    "archive/zip"
+    "bytes"
+    "crypto/sha256"
+    "encoding/hex"
+    "encoding/json"
+    "fmt"
+    "sort"
+    "time"
+)
+
+// MergeEvidencePackages merges multiple evidence ZIP bytes into a single ZIP.
+func MergeEvidencePackages(packages [][]byte, opts ExportOptions) ([]byte, error) {
+    if len(packages) == 0 {
+        return nil, fmt.Errorf("no packages to merge")
+    }
+
+    var mergedJobs []MergedJobEntry
+    totalEvents := 0
+    var rootHashes []string
+
+    buf := new(bytes.Buffer)
+    zw := zip.NewWriter(buf)
+
+    for i, pkgBytes := range packages {
+        entries, err := readZipEntries(bytes.NewReader(pkgBytes))
+        if err != nil {
+            return nil, fmt.Errorf("package %d: %w", i, err)
+        }
+
+        jobFilename := fmt.Sprintf("job_%03d.zip", i+1)
+        w, err := zw.Create(jobFilename)
+        if err != nil {
+            return nil, fmt.Errorf("create entry %s: %w", jobFilename, err)
+        }
+        if _, err := w.Write(pkgBytes); err != nil {
+            return nil, fmt.Errorf("write entry %s: %w", jobFilename, err)
+        }
+
+        // Extract metadata from manifest
+        if manifestData, ok := entries["manifest.json"]; ok {
+            var m Manifest
+            if err := json.Unmarshal(manifestData, &m); err == nil {
+                mergedJobs = append(mergedJobs, MergedJobEntry{
+                    JobID:       m.JobID,
+                    RootHash:    m.LastEventHash,
+                    EventCount:  m.EventCount,
+                    LedgerCount: m.LedgerCount,
+                    Filename:    jobFilename,
+                })
+                rootHashes = append(rootHashes, m.LastEventHash)
+                totalEvents += m.EventCount
+            }
+        }
+    }
+
+    // Sort by JobID for deterministic output
+    sort.Slice(mergedJobs, func(i, j int) bool {
+        return mergedJobs[i].JobID < mergedJobs[j].JobID
+    })
+
+    // Compute overall root hash
+    overallRootHash := computeOverallRootHash(rootHashes)
+
+    mergedManifest := MergedManifest{
+        Version:         "2.0",
+        MergedAt:        time.Now().UTC(),
+        JobCount:        len(mergedJobs),
+        Jobs:            mergedJobs,
+        TotalEventCount: totalEvents,
+        OverallRootHash: overallRootHash,
+    }
+
+    mergedManifestJSON, _ := json.MarshalIndent(mergedManifest, "", "  ")
+    fw, _ := zw.Create("manifest.json")
+    fw.Write(mergedManifestJSON)
+    zw.Close()
+
+    return buf.Bytes(), nil
+}
+
+func computeOverallRootHash(hashes []string) string {
+    sort.Strings(hashes)
+    h := sha256.New()
+    for _, rh := range hashes {
+        h.Write([]byte(rh))
+    }
+    return hex.EncodeToString(h.Sum(nil))
+}
+```
+
+**Step 3: Add test**
+
+```go
+func TestMergeEvidencePackages(t *testing.T) {
+    // Create two minimal evidence packages
+    events1 := []Event{{ID: "1", JobID: "job_1", Type: "job_created", Hash: "hash1"}}
+    events2 := []Event{{ID: "2", JobID: "job_2", Type: "job_created", Hash: "hash2"}}
+    m1 := Manifest{JobID: "job_1", LastEventHash: "hash1", EventCount: 1}
+    m2 := Manifest{JobID: "job_2", LastEventHash: "hash2", EventCount: 1}
+
+    pkg1, _ := buildTestPackage("job_1", events1, m1)
+    pkg2, _ := buildTestPackage("job_2", events2, m2)
+
+    merged, err := MergeEvidencePackages([][]byte{pkg1, pkg2}, ExportOptions{})
+    if err != nil {
+        t.Fatalf("merge failed: %v", err)
+    }
+
+    // Verify merged ZIP can be opened
+    zr, err := zip.NewReader(bytes.NewReader(merged), int64(len(merged)))
+    if err != nil {
+        t.Fatalf("merged zip unreadable: %v", err)
+    }
+    names := make(map[string]bool)
+    for _, f := range zr.File {
+        names[f.Name] = true
+    }
+    if !names["manifest.json"] {
+        t.Error("merged zip missing manifest.json")
+    }
+    if !names["job_0001.zip"] || !names["job_0002.zip"] {
+        t.Error("merged zip missing job entries")
+    }
+}
+```
+
+**Step 4: Run tests**
+
+```bash
+go test ./pkg/proof/... -v -run TestMerge
+```
+
+**Step 5: Commit**
+
+```bash
+git add pkg/proof/merge.go pkg/proof/merge_test.go
+git commit -m "feat(proof): add evidence package merge for multi-job compliance reports"
+```
+
+---
+
+## Task 5: Compliance Policy Engine
+
+**Files:**
+
+- Create: `pkg/compliance/policy.go` — policy definition and matcher
+- Create: `pkg/compliance/policy_test.go`
+- Modify: `internal/agent/runtime/runner.go` — trigger evidence collection on job completion
+
+**Step 1: Define policy types**
+
+```go
+package compliance
+
+// Policy defines when evidence must be collected.
+type Policy struct {
+    Name        string            `yaml:"name"`
+    Description string            `yaml:"description"`
+    Enabled     bool              `yaml:"enabled"`
+    Conditions  []PolicyCondition `yaml:"conditions"`
+    Actions     []PolicyAction    `yaml:"actions"`
+}
+
+type PolicyCondition struct {
+    Field    string   `yaml:"field"`     // agent_id, tool_names, job_tag, status
+    Operator string   `yaml:"operator"`  // contains, equals, regex_match
+    Values   []string `yaml:"values"`
+}
+
+type PolicyAction struct {
+    Type string `yaml:"type"` // "collect_evidence", "notify", "require_approval"
+}
+
+// Match returns true if the job satisfies all conditions.
+func (p *Policy) Match(job *JobContext) bool {
+    if !p.Enabled {
+        return false
+    }
+    for _, cond := range p.Conditions {
+        if !cond.Matches(job) {
+            return false
+        }
+    }
+    return true
+}
+```
+
+**Step 2: Implement condition matching**
+
+```go
+func (c *PolicyCondition) Matches(job *JobContext) bool {
+    var fieldValue string
+    switch c.Field {
+    case "agent_id":
+        fieldValue = job.AgentID
+    case "status":
+        fieldValue = job.Status
+    case "tool_names":
+        return c.matchesToolNames(job.ToolNames)
+    case "job_tag":
+        return c.matchesJobTags(job.Tags)
+    }
+    return c.matchesString(fieldValue)
+}
+
+func (c *PolicyCondition) matchesString(value string) bool {
+    switch c.Operator {
+    case "equals":
+        for _, v := range c.Values {
+            if value == v {
+                return true
+            }
+        }
+    case "contains":
+        for _, v := range c.Values {
+            if strings.Contains(value, v) {
+                return true
+            }
+        }
+    case "regex_match":
+        for _, v := range c.Values {
+            matched, _ := regexp.MatchString(v, value)
+            if matched {
+                return true
+            }
+        }
+    }
+    return false
+}
+
+func (c *PolicyCondition) matchesToolNames(names []string) bool {
+    for _, name := range names {
+        if c.matchesString(name) {
+            return true
+        }
+    }
+    return false
+}
+```
+
+**Step 3: Wire into job completion**
+
+In `internal/agent/runtime/runner.go`, after a job completes, call the policy engine:
+
+```go
+// After job completion, check compliance policies
+ctx := compliance.NewContext(job)
+for _, policy := range compliancePolicies {
+    if policy.Match(ctx) {
+        for _, action := range policy.Actions {
+            if action.Type == "collect_evidence" {
+                go func(jobID string) {
+                    if err := h.collectEvidenceForJob(ctx, jobID); err != nil {
+                        hlog.Errorf("compliance evidence collection failed for job %s: %v", jobID, err)
+                    }
+                }(job.ID)
+            }
+        }
+    }
+}
+```
+
+**Step 4: Add config example**
+
+Add to `configs/compliance.yaml`:
+
+```yaml
+policies:
+  - name: "payment-evidence"
+    enabled: true
+    description: "Collect evidence for all payment-related jobs"
+    conditions:
+      - field: "tool_names"
+        operator: "contains"
+        values: ["stripe", "payment", "paypal"]
+    actions:
+      - type: "collect_evidence"
+
+  - name: "high-value-transactions"
+    enabled: true
+    description: "Extra evidence for high-value transactions"
+    conditions:
+      - field: "job_tag"
+        operator: "equals"
+        values: ["high_value"]
+    actions:
+      - type: "collect_evidence"
+      - type: "notify"
+```
+
+**Step 5: Write tests**
+
+```go
+func TestPolicyMatching(t *testing.T) {
+    policy := Policy{
+        Name:    "payment-policy",
+        Enabled: true,
+        Conditions: []PolicyCondition{
+            {Field: "tool_names", Operator: "contains", Values: []string{"stripe"}},
+        },
+        Actions: []PolicyAction{{Type: "collect_evidence"}},
+    }
+
+    ctx := &JobContext{
+        AgentID:   "agent_1",
+        Status:    "completed",
+        ToolNames: []string{"http_call", "stripe.charge"},
+    }
+
+    if !policy.Match(ctx) {
+        t.Error("expected policy to match job with stripe tool")
+    }
+
+    ctx2 := &JobContext{
+        AgentID:   "agent_1",
+        Status:    "completed",
+        ToolNames: []string{"http_call", "calculator"},
+    }
+    if policy.Match(ctx2) {
+        t.Error("expected policy NOT to match job without stripe tool")
+    }
+}
+```
+
+**Step 6: Run tests**
+
+```bash
+go test ./pkg/compliance/... -v
+```
+
+**Step 7: Commit**
+
+```bash
+git add pkg/compliance/policy.go pkg/compliance/policy_test.go
+git commit -m "feat(compliance): add policy engine for automatic evidence collection"
+```
+
+---
+
+## Task 6: Semantic Verification — Detect "Claimed Success but Actually Failed"
+
+**Files:**
+
+- Modify: `pkg/proof/verify.go:26-216` — add semantic verification pass
+- Create: `pkg/proof/semantic_verify.go`
+- Create: `pkg/proof/semantic_verify_test.go`
+
+**Step 1: Add semantic verification**
+
+The existing `ValidateLedgerConsistency` checks structural consistency. Add a semantic check that detects if the event record says "success" but the actual result contains an error:
+
+```go
+// SemanticVerificationResult holds semantic verification results.
+type SemanticVerificationResult struct {
+    OK              bool
+    FraudIndicators []FraudIndicator
+}
+
+type FraudIndicator struct {
+    Type        string // "success_claimed_but_error_in_result", "tool_not_called_but_marked_success"
+    InvocationID string
+    Details      string
+}
+
+// SemanticVerify performs semantic checks beyond structural integrity.
+func SemanticVerify(events []Event, ledger []ToolInvocation) SemanticVerificationResult {
+    result := SemanticVerificationResult{OK: true}
+
+    // Build event-derived tool invocations map
+    eventInvocations := buildInvocationMapFromEvents(events)
+
+    for _, inv := range ledger {
+        if inv.Status != "success" && inv.Status != "committed" {
+            continue
+        }
+
+        eventInv, ok := eventInvocations[inv.IdempotencyKey]
+        if !ok {
+            result.OK = false
+            result.FraudIndicators = append(result.FraudIndicators, FraudIndicator{
+                Type:        "success_claimed_but_not_in_events",
+                InvocationID: inv.ID,
+                Details:     "Ledger claims success but no corresponding event found",
+            })
+            continue
+        }
+
+        // Check if result contains an error even though status is "success"
+        if hasErrorInResult(inv.Result) && eventInv.Outcome == "success" {
+            result.OK = false
+            result.FraudIndicators = append(result.FraudIndicators, FraudIndicator{
+                Type:        "success_claimed_but_error_in_result",
+                InvocationID: inv.ID,
+                Details:     fmt.Sprintf("Status=success but result contains error: %s", truncate(inv.Result, 200)),
+            })
+        }
+    }
+
+    return result
+}
+
+func hasErrorInResult(result string) bool {
+    if result == "" {
+        return false
+    }
+    // Check for common error patterns in result JSON
+    var m map[string]interface{}
+    if err := json.Unmarshal([]byte(result), &m); err != nil {
+        return false
+    }
+    // Check top-level error field
+    if _, ok := m["error"]; ok {
+        return true
+    }
+    if status, ok := m["status"].(string); ok && status == "error" {
+        return true
+    }
+    return false
+}
+```
+
+**Step 2: Integrate into VerifyEvidenceZip**
+
+In `pkg/proof/verify.go`, add to `VerifyResult`:
+
+```go
+type VerifyResult struct {
+    // ... existing fields ...
+    SemanticOK         bool               `json:"semantic_ok"`
+    FraudIndicators    []FraudIndicator   `json:"fraud_indicators,omitempty"`
+}
+```
+
+After ledger validation, call `SemanticVerify` and populate the fields.
+
+**Step 3: Write tests**
+
+```go
+func TestSemanticVerify_DetectsFalseSuccess(t *testing.T) {
+    events := []Event{{ID: "1", Type: "tool_invocation_finished", Payload: `{"idempotency_key":"k1","outcome":"success","tool_name":"payment"}`}}
+    ledger := []ToolInvocation{{ID: "inv1", IdempotencyKey: "k1", Status: "success", Result: `{"error":"charge failed: insufficient funds"}`}}
+
+    result := SemanticVerify(events, ledger)
+    if result.OK {
+        t.Error("expected semantic verification to fail")
+    }
+    if len(result.FraudIndicators) == 0 {
+        t.Error("expected fraud indicator")
+    }
+}
+```
+
+**Step 4: Run tests**
+
+```bash
+go test ./pkg/proof/... -v -run TestSemantic
+```
+
+**Step 5: Commit**
+
+```bash
+git add pkg/proof/semantic_verify.go pkg/proof/semantic_verify_test.go pkg/proof/verify.go
+git commit -m "feat(proof): add semantic verification to detect fraud indicators in evidence"
+```
+
+---
+
+## Task 7: Evidence Retention Policy Per Tenant
+
+**Files:**
+
+- Create: `pkg/compliance/retention.go` — retention policy definition and GC
+- Create: `pkg/compliance/retention_test.go`
+- Modify: `configs/compliance.yaml` — add retention section
+
+**Step 1: Define retention policy**
+
+```go
+package compliance
+
+// RetentionPolicy defines how long evidence is kept per tenant.
+type RetentionPolicy struct {
+    TenantID      string        `yaml:"tenant_id"`
+    EvidenceTTL   time.Duration `yaml:"evidence_ttl"`    // e.g., 7 years for financial, 1 year general
+    Enabled       bool          `yaml:"enabled"`
+    ArchiveBefore time.Time     `yaml:"archive_before"`  // Move to cold storage before this date
+}
+
+// ShouldRetain returns true if evidence for the given job should be retained.
+func (p *RetentionPolicy) ShouldRetain(jobCreatedAt time.Time, evidenceAge time.Duration) bool {
+    if !p.Enabled {
+        return false
+    }
+    return evidenceAge < p.EvidenceTTL
+}
+```
+
+**Step 2: Add GC logic**
+
+```go
+// CollectExpiredEvidence returns job IDs whose evidence has exceeded retention TTL.
+func (p *RetentionPolicy) CollectExpiredEvidence(ctx context.Context, store EvidenceStore) ([]string, error) {
+    if !p.Enabled {
+        return nil, nil
+    }
+
+    cutoff := time.Now().UTC().Add(-p.EvidenceTTL)
+    jobs, err := store.ListJobsCreatedBefore(ctx, p.TenantID, cutoff)
+    if err != nil {
+        return nil, err
+    }
+
+    expired := make([]string, 0)
+    for _, job := range jobs {
+        if !p.ShouldRetain(job.CreatedAt, time.Since(job.CreatedAt)) {
+            expired = append(expired, job.ID)
+        }
+    }
+    return expired, nil
+}
+```
+
+**Step 3: Add config example**
+
+```yaml
+# configs/compliance.yaml
+retention:
+  policies:
+    - tenant_id: "financial_customer_a"
+      evidence_ttl: "87600h" # 10 years
+      enabled: true
+    - tenant_id: "default"
+      evidence_ttl: "8760h" # 1 year
+      enabled: true
+```
+
+**Step 4: Commit**
+
+```bash
+git add pkg/compliance/retention.go pkg/compliance/retention_test.go
+git commit -m "feat(compliance): add evidence retention policy per tenant"
+```
+
+---
+
+## Task 8: Documentation
+
+**Files:**
+
+- Modify: `docs/concepts/evidence-package.md` — update to reflect new features
+
+**Step 1: Update docs**
+
+Document the new features: digital signatures, semantic verification, policy engine, retention policies, merge functionality.
+
+**Step 2: Commit**
+
+```bash
+git add docs/concepts/evidence-package.md
+git commit -m "docs: update evidence package docs with Phase 1-4 features"
+```
+
+---
+
+## Plan Summary
+
+| Task | Description                                        | Files                                                          |
+| ---- | -------------------------------------------------- | -------------------------------------------------------------- |
+| 1    | Ed25519 digital signatures on evidence packages    | `pkg/proof/signature.go`, `types.go`, `export.go`, `verify.go` |
+| 2    | Wire signing config into REST API export           | `internal/api/http/forensics.go`, `configs/api.yaml`           |
+| 3    | SHA256 hash for all ZIP files                      | `pkg/proof/export.go`                                          |
+| 4    | Evidence package merge for multi-job reports       | `pkg/proof/merge.go`                                           |
+| 5    | Compliance policy engine (auto-trigger collection) | `pkg/compliance/policy.go`                                     |
+| 6    | Semantic verification (fraud detection)            | `pkg/proof/semantic_verify.go`                                 |
+| 7    | Evidence retention policy per tenant               | `pkg/compliance/retention.go`                                  |
+| 8    | Documentation update                               | `docs/concepts/evidence-package.md`                            |
+
+**Execution approach:** Subagent-Driven (this session) — dispatch fresh subagent per task with review between tasks.
+
+**Which approach?**

--- a/pkg/proof/export.go
+++ b/pkg/proof/export.go
@@ -117,9 +117,28 @@ func ExportEvidenceZip(
 		GeneratedBy:     fmt.Sprintf("aetheris %s", opts.RuntimeVersion),
 	}
 
-	proofJSON, err := json.MarshalIndent(proofSummary, "", "  ")
-	if err != nil {
-		return nil, fmt.Errorf("failed to serialize proof: %w", err)
+	// 如果提供了 SigningConfig，则签名证据包
+	var proofJSON []byte
+	if len(opts.SigningConfig.PrivateKey) > 0 {
+		sig, err := SignEvidence(opts.SigningConfig.PrivateKey, manifest, events, toolInvocations)
+		if err != nil {
+			return nil, fmt.Errorf("failed to sign evidence: %w", err)
+		}
+		signedProof := SignedProof{
+			ProofSummary: proofSummary,
+			Signature:    sig,
+			SignedAt:     SignedAt(),
+			SignerKeyID:  "default",
+		}
+		proofJSON, err = json.MarshalIndent(signedProof, "", "  ")
+		if err != nil {
+			return nil, fmt.Errorf("failed to serialize signed proof: %w", err)
+		}
+	} else {
+		proofJSON, err = json.MarshalIndent(proofSummary, "", "  ")
+		if err != nil {
+			return nil, fmt.Errorf("failed to serialize proof: %w", err)
+		}
 	}
 
 	fileHashes["proof.json"] = ComputeFileHash(proofJSON)

--- a/pkg/proof/integration_test.go
+++ b/pkg/proof/integration_test.go
@@ -79,7 +79,7 @@ func TestEndToEnd_ExportAndVerify(t *testing.T) {
 	}
 
 	// 3. 验证证据包
-	result := VerifyEvidenceZip(zipBytes)
+	result := VerifyEvidenceZip(zipBytes, nil)
 	if !result.OK {
 		t.Errorf("verification should pass, errors: %v", result.Errors)
 	}
@@ -119,7 +119,7 @@ func TestEndToEnd_TamperDetection(t *testing.T) {
 	}
 
 	// 验证原始证据包（应该通过）
-	result := VerifyEvidenceZip(zipBytes)
+	result := VerifyEvidenceZip(zipBytes, nil)
 	if !result.OK {
 		t.Fatalf("original package should verify, errors: %v", result.Errors)
 	}
@@ -133,7 +133,7 @@ func TestEndToEnd_TamperDetection(t *testing.T) {
 	})
 
 	// 验证篡改后的证据包（应该失败）
-	tamperedResult := VerifyEvidenceZip(tamperedZip)
+	tamperedResult := VerifyEvidenceZip(tamperedZip, nil)
 	if tamperedResult.OK {
 		t.Error("tampered package should fail verification")
 	}
@@ -188,7 +188,7 @@ func TestEndToEnd_ChainIntegrity(t *testing.T) {
 		t.Fatalf("export failed: %v", err)
 	}
 
-	result := VerifyEvidenceZip(zipBytes)
+	result := VerifyEvidenceZip(zipBytes, nil)
 	if !result.OK {
 		t.Errorf("verification failed: %v", result.Errors)
 	}

--- a/pkg/proof/signature.go
+++ b/pkg/proof/signature.go
@@ -1,0 +1,62 @@
+// Copyright 2026 fanjia1024
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proof
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"golang.org/x/crypto/ed25519"
+)
+
+// SignEvidence signs the evidence package contents and returns a signature.
+func SignEvidence(privateKey ed25519.PrivateKey, manifest Manifest, events []Event, ledger []ToolInvocation) (string, error) {
+	manifestBytes, _ := json.Marshal(manifest)
+	eventsBytes, _ := eventsToNDJSON(events)
+	ledgerBytes, _ := ledgerToNDJSON(ledger)
+
+	payload := append(manifestBytes, eventsBytes...)
+	payload = append(payload, ledgerBytes...)
+
+	sig := ed25519.Sign(privateKey, payload)
+	return base64.StdEncoding.EncodeToString(sig), nil
+}
+
+// VerifySignature verifies an Ed25519 signature against the evidence package contents.
+func VerifySignature(publicKey ed25519.PublicKey, manifest Manifest, events []Event, ledger []ToolInvocation, signature string) error {
+	sigBytes, err := base64.StdEncoding.DecodeString(signature)
+	if err != nil {
+		return fmt.Errorf("invalid signature encoding: %w", err)
+	}
+
+	manifestBytes, _ := json.Marshal(manifest)
+	eventsBytes, _ := eventsToNDJSON(events)
+	ledgerBytes, _ := ledgerToNDJSON(ledger)
+
+	payload := append(manifestBytes, eventsBytes...)
+	payload = append(payload, ledgerBytes...)
+
+	if !ed25519.Verify(publicKey, payload, sigBytes) {
+		return fmt.Errorf("signature verification failed")
+	}
+	return nil
+}
+
+// SignedAt returns current time in ISO 8601 format.
+func SignedAt() string {
+	return time.Now().UTC().Format(time.RFC3339)
+}

--- a/pkg/proof/signature_test.go
+++ b/pkg/proof/signature_test.go
@@ -1,0 +1,134 @@
+// Copyright 2026 fanjia1024
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proof
+
+import (
+	"crypto/ed25519"
+	"testing"
+	"time"
+)
+
+func TestSignAndVerifyEvidence(t *testing.T) {
+	publicKey, privateKey, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	events := []Event{
+		{ID: "1", JobID: "job_test", Type: "job_created", Hash: "abc", CreatedAt: time.Now()},
+	}
+	ledger := []ToolInvocation{
+		{ID: "inv1", JobID: "job_test", IdempotencyKey: "key1"},
+	}
+	manifest := Manifest{JobID: "job_test", Version: "2.0"}
+
+	sig, err := SignEvidence(privateKey, manifest, events, ledger)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	err = VerifySignature(publicKey, manifest, events, ledger, sig)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+}
+
+func TestSignAndVerifyEvidence_TamperedContent(t *testing.T) {
+	publicKey, privateKey, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	events := []Event{
+		{ID: "1", JobID: "job_test", Type: "job_created", Hash: "abc", CreatedAt: time.Now()},
+	}
+	ledger := []ToolInvocation{
+		{ID: "inv1", JobID: "job_test", IdempotencyKey: "key1"},
+	}
+	manifest := Manifest{JobID: "job_test", Version: "2.0"}
+
+	sig, err := SignEvidence(privateKey, manifest, events, ledger)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	// Tamper with events
+	tamperedEvents := []Event{
+		{ID: "1", JobID: "job_test", Type: "job_created", Hash: "tampered", CreatedAt: time.Now()},
+	}
+
+	err = VerifySignature(publicKey, manifest, tamperedEvents, ledger, sig)
+	if err == nil {
+		t.Fatal("expected verification to fail with tampered content, but it passed")
+	}
+}
+
+func TestSignAndVerifyEvidence_WrongKey(t *testing.T) {
+	_, privateKey, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	_, anotherPrivateKey, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	events := []Event{
+		{ID: "1", JobID: "job_test", Type: "job_created", Hash: "abc", CreatedAt: time.Now()},
+	}
+	ledger := []ToolInvocation{
+		{ID: "inv1", JobID: "job_test", IdempotencyKey: "key1"},
+	}
+	manifest := Manifest{JobID: "job_test", Version: "2.0"}
+
+	sig, err := SignEvidence(privateKey, manifest, events, ledger)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	// Verify with wrong public key (from different key pair)
+	err = VerifySignature(anotherPrivateKey.Public().(ed25519.PublicKey), manifest, events, ledger, sig)
+	if err == nil {
+		t.Fatal("expected verification to fail with wrong public key, but it passed")
+	}
+}
+
+func TestSignEvidence_InvalidSignatureEncoding(t *testing.T) {
+	publicKey, privateKey, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	events := []Event{
+		{ID: "1", JobID: "job_test", Type: "job_created", Hash: "abc", CreatedAt: time.Now()},
+	}
+	ledger := []ToolInvocation{}
+	manifest := Manifest{JobID: "job_test", Version: "2.0"}
+
+	// Sign with valid key
+	sig, err := SignEvidence(privateKey, manifest, events, ledger)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	// Corrupt the signature
+	corruptedSig := sig[:len(sig)-4] + "XXXX"
+
+	// Verify should fail
+	err = VerifySignature(publicKey, manifest, events, ledger, corruptedSig)
+	if err == nil {
+		t.Fatal("expected verification to fail with corrupted signature, but it passed")
+	}
+}

--- a/pkg/proof/types.go
+++ b/pkg/proof/types.go
@@ -96,8 +96,8 @@ type ExportOptions struct {
 	RuntimeVersion   string
 	SchemaVersion    string
 	IncludeReasoning bool
-	RedactionEnabled bool         // 2.0-M2: 是否启用脱敏
-	RedactionSalt    string       // 2.0-M2: Hash 模式的 salt
+	RedactionEnabled bool          // 2.0-M2: 是否启用脱敏
+	RedactionSalt    string        // 2.0-M2: Hash 模式的 salt
 	SigningConfig    SigningConfig // Ed25519 signing config (optional)
 }
 
@@ -121,9 +121,9 @@ type SigningConfig struct {
 // SignedProof extends ProofSummary with cryptographic signature.
 type SignedProof struct {
 	ProofSummary
-	Signature    string `json:"signature,omitempty"`    // Base64-encoded Ed25519 signature
-	SignedAt     string `json:"signed_at,omitempty"`    // ISO 8601 timestamp
-	SignerKeyID  string `json:"signer_key_id,omitempty"` // Identifier for the signing key
+	Signature   string `json:"signature,omitempty"`     // Base64-encoded Ed25519 signature
+	SignedAt    string `json:"signed_at,omitempty"`     // ISO 8601 timestamp
+	SignerKeyID string `json:"signer_key_id,omitempty"` // Identifier for the signing key
 }
 
 // JobStore 接口（用于导出）

--- a/pkg/proof/types.go
+++ b/pkg/proof/types.go
@@ -17,6 +17,8 @@ package proof
 import (
 	"context"
 	"time"
+
+	"golang.org/x/crypto/ed25519"
 )
 
 // EvidencePackage 证据包结构
@@ -94,8 +96,9 @@ type ExportOptions struct {
 	RuntimeVersion   string
 	SchemaVersion    string
 	IncludeReasoning bool
-	RedactionEnabled bool   // 2.0-M2: 是否启用脱敏
-	RedactionSalt    string // 2.0-M2: Hash 模式的 salt
+	RedactionEnabled bool         // 2.0-M2: 是否启用脱敏
+	RedactionSalt    string       // 2.0-M2: Hash 模式的 salt
+	SigningConfig    SigningConfig // Ed25519 signing config (optional)
 }
 
 // VerifyResult 验证结果
@@ -107,6 +110,20 @@ type VerifyResult struct {
 	LedgerValid    bool
 	HashChainValid bool
 	ManifestValid  bool
+	SignatureValid bool
+}
+
+// SigningConfig contains Ed25519 private key for signing evidence packages.
+type SigningConfig struct {
+	PrivateKey ed25519.PrivateKey
+}
+
+// SignedProof extends ProofSummary with cryptographic signature.
+type SignedProof struct {
+	ProofSummary
+	Signature    string `json:"signature,omitempty"`    // Base64-encoded Ed25519 signature
+	SignedAt     string `json:"signed_at,omitempty"`    // ISO 8601 timestamp
+	SignerKeyID  string `json:"signer_key_id,omitempty"` // Identifier for the signing key
 }
 
 // JobStore 接口（用于导出）

--- a/pkg/proof/verify.go
+++ b/pkg/proof/verify.go
@@ -17,6 +17,7 @@ package proof
 import (
 	"archive/zip"
 	"bytes"
+	"crypto/ed25519"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -24,7 +25,8 @@ import (
 )
 
 // VerifyEvidenceZip 验证证据包 ZIP
-func VerifyEvidenceZip(zipBytes []byte) VerifyResult {
+// If publicKey is provided (non-nil), signature verification will be performed.
+func VerifyEvidenceZip(zipBytes []byte, publicKey ed25519.PublicKey) VerifyResult {
 	result := VerifyResult{
 		OK:     true,
 		Errors: []string{},
@@ -135,15 +137,26 @@ func VerifyEvidenceZip(zipBytes []byte) VerifyResult {
 	// 8. 验证 proof summary
 	proofData, ok := files["proof.json"]
 	if ok {
-		var proofSummary ProofSummary
-		if err := json.Unmarshal(proofData, &proofSummary); err != nil {
+		// 先尝试解析为 SignedProof（包含签名）
+		var signedProof SignedProof
+		if err := json.Unmarshal(proofData, &signedProof); err != nil {
 			result.OK = false
 			result.Errors = append(result.Errors, fmt.Sprintf("failed to parse proof: %v", err))
 		} else {
 			// 验证 root_hash == 最后一个事件的 hash
-			if len(events) > 0 && proofSummary.RootHash != events[len(events)-1].Hash {
+			if len(events) > 0 && signedProof.RootHash != events[len(events)-1].Hash {
 				result.OK = false
-				result.Errors = append(result.Errors, fmt.Sprintf("proof root_hash mismatch: expected %s, got %s", events[len(events)-1].Hash, proofSummary.RootHash))
+				result.Errors = append(result.Errors, fmt.Sprintf("proof root_hash mismatch: expected %s, got %s", events[len(events)-1].Hash, signedProof.RootHash))
+			}
+			// 如果存在签名且提供了公钥，则验证签名
+			if signedProof.Signature != "" && publicKey != nil {
+				if err := VerifySignatureFromZipWithKey(files, signedProof.Signature, publicKey); err != nil {
+					result.OK = false
+					result.SignatureValid = false
+					result.Errors = append(result.Errors, fmt.Sprintf("signature verification failed: %v", err))
+				} else {
+					result.SignatureValid = true
+				}
 			}
 		}
 	}
@@ -249,4 +262,36 @@ func parseLedgerNDJSON(data []byte) ([]ToolInvocation, error) {
 		ledger = append(ledger, inv)
 	}
 	return ledger, nil
+}
+
+// VerifySignatureFromZipWithKey verifies Ed25519 signature against evidence package contents from zip files using provided public key.
+func VerifySignatureFromZipWithKey(files map[string][]byte, signature string, publicKey ed25519.PublicKey) error {
+	manifestData, ok := files["manifest.json"]
+	if !ok {
+		return fmt.Errorf("manifest.json not found")
+	}
+	var manifest Manifest
+	if err := json.Unmarshal(manifestData, &manifest); err != nil {
+		return fmt.Errorf("failed to parse manifest: %w", err)
+	}
+
+	eventsData, ok := files["events.ndjson"]
+	if !ok {
+		return fmt.Errorf("events.ndjson not found")
+	}
+	events, err := parseEventsNDJSON(eventsData)
+	if err != nil {
+		return fmt.Errorf("failed to parse events: %w", err)
+	}
+
+	ledgerData, ok := files["ledger.ndjson"]
+	var ledger []ToolInvocation
+	if ok {
+		ledger, err = parseLedgerNDJSON(ledgerData)
+		if err != nil {
+			return fmt.Errorf("failed to parse ledger: %w", err)
+		}
+	}
+
+	return VerifySignature(publicKey, manifest, events, ledger, signature)
 }

--- a/pkg/proof/verify.go
+++ b/pkg/proof/verify.go
@@ -17,19 +17,27 @@ package proof
 import (
 	"archive/zip"
 	"bytes"
-	"crypto/ed25519"
 	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
+
+	"golang.org/x/crypto/ed25519"
 )
 
 // VerifyEvidenceZip 验证证据包 ZIP
 // If publicKey is provided (non-nil), signature verification will be performed.
-func VerifyEvidenceZip(zipBytes []byte, publicKey ed25519.PublicKey) VerifyResult {
+// The publicKey parameter is optional - pass no argument or nil to skip signature verification.
+func VerifyEvidenceZip(zipBytes []byte, publicKey ...ed25519.PublicKey) VerifyResult {
 	result := VerifyResult{
 		OK:     true,
 		Errors: []string{},
+	}
+
+	// Extract publicKey from variadic argument
+	var pubKey ed25519.PublicKey
+	if len(publicKey) > 0 {
+		pubKey = publicKey[0]
 	}
 
 	// 1. 解压 ZIP
@@ -149,8 +157,8 @@ func VerifyEvidenceZip(zipBytes []byte, publicKey ed25519.PublicKey) VerifyResul
 				result.Errors = append(result.Errors, fmt.Sprintf("proof root_hash mismatch: expected %s, got %s", events[len(events)-1].Hash, signedProof.RootHash))
 			}
 			// 如果存在签名且提供了公钥，则验证签名
-			if signedProof.Signature != "" && publicKey != nil {
-				if err := VerifySignatureFromZipWithKey(files, signedProof.Signature, publicKey); err != nil {
+			if signedProof.Signature != "" && pubKey != nil {
+				if err := VerifySignatureFromZipWithKey(files, signedProof.Signature, pubKey); err != nil {
 					result.OK = false
 					result.SignatureValid = false
 					result.Errors = append(result.Errors, fmt.Sprintf("signature verification failed: %v", err))

--- a/pkg/proof/verify_test.go
+++ b/pkg/proof/verify_test.go
@@ -74,7 +74,7 @@ func TestEvidence_Valid(t *testing.T) {
 		t.Fatalf("export failed: %v", err)
 	}
 
-	result := VerifyEvidenceZip(zipBytes)
+	result := VerifyEvidenceZip(zipBytes, nil)
 	if !result.OK {
 		t.Errorf("verification should pass, but got errors: %v", result.Errors)
 	}
@@ -109,7 +109,7 @@ func TestEvidence_TamperEvent(t *testing.T) {
 		return b
 	})
 
-	result := VerifyEvidenceZip(tamperedZip)
+	result := VerifyEvidenceZip(tamperedZip, nil)
 	if result.OK {
 		t.Error("verification should fail after tampering")
 	}
@@ -134,7 +134,7 @@ func TestEvidence_DeleteMiddleEvent(t *testing.T) {
 		return deleteNDJSONLine(b, 5)
 	})
 
-	result := VerifyEvidenceZip(tamperedZip)
+	result := VerifyEvidenceZip(tamperedZip, nil)
 	if result.OK {
 		t.Error("verification should fail after deleting event")
 	}
@@ -167,7 +167,7 @@ func TestEvidence_LedgerMismatch(t *testing.T) {
 		t.Fatalf("export failed: %v", err)
 	}
 
-	result := VerifyEvidenceZip(zipBytes)
+	result := VerifyEvidenceZip(zipBytes, nil)
 	// 验证应该失败（ledger 不一致）
 	if result.LedgerValid {
 		t.Error("ledger validation should fail when event finished but ledger missing")


### PR DESCRIPTION
- Modify calls to VerifyEvidenceZip in integration and verification tests to include a nil parameter for optional publicKey, ensuring consistency with recent changes in signature verification logic.

## Summary

Describe the change and why it is needed.

## Changes

- 

## Validation

- [ ] `go test ./...`
- [ ] `go build ./...`
- [ ] docs updated when behavior changed

## Compatibility / Risk

Call out breaking changes, migrations, or runtime risks.

## Related Issues

Link related issues (e.g. `Closes #123`).

