### PR TITLE
feat(hitl): HITL Approval Engine Phase 1

### DIFF
--- a/docs/releases/RELEASE-NOTES-2.4.0.md
+++ b/docs/releases/RELEASE-NOTES-2.4.0.md
@@ -1,0 +1,87 @@
+# Aetheris v2.4.0 Release Notes
+
+**Release Date:** 2026-03-24
+
+---
+
+## Highlights
+
+Aetheris v2.4.0 introduces the **Human-in-the-Loop (HITL) Approval Engine Phase 1** — a structured approval request API built on top of the existing Wait/Signal primitives. This release lays the foundation for enterprise compliance workflows where human sign-off is required before AI agents execute high-stakes actions.
+
+---
+
+## What's New
+
+### HITL Approval Engine (Phase 1)
+
+- **Structured ApprovalRequest API**: `POST /api/approvals`, `GET /api/approvals`, `GET /api/approvals/:id`
+- **Approval Actions**: `POST /api/approvals/:id/approve`, `POST /api/approvals/:id/reject`
+- **Approval Event Types**: `approval_requested` and `approval_completed` events written to the job event store
+- **ApprovalStore Interface**: Pluggable storage backend (`NewMemStore()` for testing/single-instance; PostgreSQL-backed store for production)
+- **Automatic Job Resume**: When an approval is completed, `wait_completed` is appended to the job event stream and the job is re-queued automatically
+- **Idempotent Signal Handling**: Leverages existing signal inbox for at-least-once delivery
+
+### New Packages
+
+| Package | Description |
+|---------|-------------|
+| `internal/agent/approval` | ApprovalRequest model, ApprovalStore interface, in-memory implementation |
+
+---
+
+## API Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/approvals` | Create an approval request |
+| `GET` | `/api/approvals` | List pending approvals (filter by `job_id` or `approver_id`) |
+| `GET` | `/api/approvals/:id` | Get a specific approval request |
+| `POST` | `/api/approvals/:id/approve` | Approve an approval request |
+| `POST` | `/api/approvals/:id/reject` | Reject an approval request |
+
+---
+
+## Approval Model
+
+```
+ApprovalRequest {
+  ID, JobID, NodeID, CorrelationKey
+  ApproverType: anyone | specific | role
+  ApproverID, Role
+  Title, Description, Payload
+  Status: pending | approved | rejected | expired | delegated
+  ApprovalResponse (after completion)
+  ExpiresAt, CreatedAt, UpdatedAt
+}
+```
+
+---
+
+## Validation
+
+- `make fmt-check` ✓
+- `make vet` ✓
+- `make test` (full suite with race detector) ✓
+- `make build` ✓
+
+---
+
+## Installation
+
+### Binary
+
+Download from [GitHub Releases](https://github.com/Colin4k1024/Aetheris/releases)
+
+### From Source
+
+```bash
+git clone https://github.com/Colin4k1024/Aetheris
+cd Aetheris
+make build
+```
+
+### Docker
+
+```bash
+docker pull aetheris/runtime:v2.4.0
+```

--- a/internal/agent/approval/mem_store.go
+++ b/internal/agent/approval/mem_store.go
@@ -1,0 +1,130 @@
+// Copyright 2026 fanjia1024
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package approval
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// MemStore 内存审批存储（仅用于测试或单实例部署）
+type MemStore struct {
+	mu    sync.RWMutex
+	items map[string]*ApprovalRequest
+}
+
+// NewMemStore 创建内存存储
+func NewMemStore() *MemStore {
+	return &MemStore{items: make(map[string]*ApprovalRequest)}
+}
+
+func (s *MemStore) Create(ctx context.Context, req *ApprovalRequest) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	req.CreatedAt = time.Now()
+	req.UpdatedAt = time.Now()
+	if req.Status == "" {
+		req.Status = DecisionPending
+	}
+	s.items[req.ID] = req
+	return nil
+}
+
+func (s *MemStore) GetByID(ctx context.Context, id string) (*ApprovalRequest, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	req, ok := s.items[id]
+	if !ok {
+		return nil, nil
+	}
+	return req, nil
+}
+
+func (s *MemStore) GetByJobID(ctx context.Context, jobID string) ([]*ApprovalRequest, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var results []*ApprovalRequest
+	for _, req := range s.items {
+		if req.JobID == jobID {
+			results = append(results, req)
+		}
+	}
+	return results, nil
+}
+
+func (s *MemStore) GetPending(ctx context.Context) ([]*ApprovalRequest, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var results []*ApprovalRequest
+	now := time.Now()
+	for _, req := range s.items {
+		if req.Status == DecisionPending && (req.ExpiresAt == nil || req.ExpiresAt.After(now)) {
+			results = append(results, req)
+		}
+	}
+	return results, nil
+}
+
+func (s *MemStore) GetPendingByApprover(ctx context.Context, approverID string) ([]*ApprovalRequest, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var results []*ApprovalRequest
+	now := time.Now()
+	for _, req := range s.items {
+		if req.Status != DecisionPending {
+			continue
+		}
+		if req.ExpiresAt != nil && req.ExpiresAt.Before(now) {
+			continue
+		}
+		switch req.ApproverType {
+		case ApproverTypeAnyone:
+			results = append(results, req)
+		case ApproverTypeSpecific:
+			if req.ApproverID == approverID {
+				results = append(results, req)
+			}
+		case ApproverTypeRole:
+			// Role-based filtering would require a role service; for now return empty
+		}
+	}
+	return results, nil
+}
+
+func (s *MemStore) Complete(ctx context.Context, id string, resp *ApprovalResponse) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	req, ok := s.items[id]
+	if !ok {
+		return nil
+	}
+	req.Status = resp.Decision
+	req.ApproverResp = resp
+	req.UpdatedAt = time.Now()
+	return nil
+}
+
+func (s *MemStore) Expire(ctx context.Context, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	req, ok := s.items[id]
+	if !ok {
+		return nil
+	}
+	req.Status = DecisionExpired
+	req.UpdatedAt = time.Now()
+	return nil
+}

--- a/internal/agent/approval/mem_store_test.go
+++ b/internal/agent/approval/mem_store_test.go
@@ -1,0 +1,144 @@
+// Copyright 2026 fanjia1024
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package approval
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestMemStore_Create(t *testing.T) {
+	store := NewMemStore()
+	ctx := context.Background()
+	req := &ApprovalRequest{
+		ID:             "apr-1",
+		JobID:          "job-1",
+		NodeID:         "node-1",
+		CorrelationKey: "corr-1",
+		ApproverType:   ApproverTypeAnyone,
+		Title:          "Test Approval",
+		Description:    "Test description",
+		Status:         DecisionPending,
+	}
+	if err := store.Create(ctx, req); err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	got, err := store.GetByID(ctx, "apr-1")
+	if err != nil {
+		t.Fatalf("GetByID failed: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected approval request, got nil")
+	}
+	if got.Title != "Test Approval" {
+		t.Errorf("title got %s, want Test Approval", got.Title)
+	}
+	if got.Status != DecisionPending {
+		t.Errorf("status got %s, want pending", got.Status)
+	}
+}
+
+func TestMemStore_Complete(t *testing.T) {
+	store := NewMemStore()
+	ctx := context.Background()
+	req := &ApprovalRequest{
+		ID:             "apr-2",
+		JobID:          "job-1",
+		NodeID:         "node-1",
+		CorrelationKey: "corr-2",
+		ApproverType:   ApproverTypeSpecific,
+		ApproverID:     "user-1",
+		Title:          "Approve Payment",
+		Status:         DecisionPending,
+	}
+	_ = store.Create(ctx, req)
+	resp := &ApprovalResponse{
+		Decision:     DecisionApproved,
+		ApproverID:   "user-1",
+		ApproverName: "John Doe",
+		Comment:      "Looks good",
+		RespondedAt:  time.Now(),
+	}
+	if err := store.Complete(ctx, "apr-2", resp); err != nil {
+		t.Fatalf("Complete failed: %v", err)
+	}
+	got, _ := store.GetByID(ctx, "apr-2")
+	if got.Status != DecisionApproved {
+		t.Errorf("status got %s, want approved", got.Status)
+	}
+	if got.ApproverResp == nil {
+		t.Fatal("expected approver response, got nil")
+	}
+	if got.ApproverResp.Comment != "Looks good" {
+		t.Errorf("comment got %s, want Looks good", got.ApproverResp.Comment)
+	}
+}
+
+func TestMemStore_GetPending(t *testing.T) {
+	store := NewMemStore()
+	ctx := context.Background()
+	store.Create(ctx, &ApprovalRequest{
+		ID:             "apr-3",
+		JobID:          "job-1",
+		CorrelationKey: "corr-3",
+		Title:          "Pending 1",
+		Status:         DecisionPending,
+	})
+	store.Create(ctx, &ApprovalRequest{
+		ID:             "apr-4",
+		JobID:          "job-2",
+		CorrelationKey: "corr-4",
+		Title:          "Pending 2",
+		Status:         DecisionPending,
+	})
+	store.Create(ctx, &ApprovalRequest{
+		ID:             "apr-5",
+		JobID:          "job-3",
+		CorrelationKey: "corr-5",
+		Title:          "Already Approved",
+		Status:         DecisionApproved,
+	})
+	store.Create(ctx, &ApprovalRequest{
+		ID:             "apr-6",
+		JobID:          "job-4",
+		CorrelationKey: "corr-6",
+		Title:          "Expired",
+		Status:         DecisionPending,
+		ExpiresAt:      &time.Time{}, // zero time = already expired
+	})
+	pending, err := store.GetPending(ctx)
+	if err != nil {
+		t.Fatalf("GetPending failed: %v", err)
+	}
+	if len(pending) != 2 {
+		t.Errorf("pending count got %d, want 2", len(pending))
+	}
+}
+
+func TestMemStore_GetByJobID(t *testing.T) {
+	store := NewMemStore()
+	ctx := context.Background()
+	store.Create(ctx, &ApprovalRequest{ID: "apr-7", JobID: "job-x", Title: "First", Status: DecisionPending})
+	store.Create(ctx, &ApprovalRequest{ID: "apr-8", JobID: "job-x", Title: "Second", Status: DecisionPending})
+	store.Create(ctx, &ApprovalRequest{ID: "apr-9", JobID: "job-y", Title: "Other", Status: DecisionPending})
+	items, err := store.GetByJobID(ctx, "job-x")
+	if err != nil {
+		t.Fatalf("GetByJobID failed: %v", err)
+	}
+	if len(items) != 2 {
+		t.Errorf("count got %d, want 2", len(items))
+	}
+}

--- a/internal/agent/approval/types.go
+++ b/internal/agent/approval/types.go
@@ -1,0 +1,87 @@
+// Copyright 2026 fanjia1024
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package approval
+
+import (
+	"context"
+	"time"
+)
+
+// Decision 审批决定
+type Decision string
+
+const (
+	DecisionPending   Decision = "pending"
+	DecisionApproved  Decision = "approved"
+	DecisionRejected  Decision = "rejected"
+	DecisionExpired   Decision = "expired"
+	DecisionDelegated Decision = "delegated"
+)
+
+// ApproverType 指定审批人的类型
+type ApproverType string
+
+const (
+	ApproverTypeAnyone   ApproverType = "anyone"   // 任何人都可以审批
+	ApproverTypeSpecific ApproverType = "specific" // 指定用户审批
+	ApproverTypeRole     ApproverType = "role"     // 指定角色审批
+)
+
+// ApprovalRequest 审批请求
+type ApprovalRequest struct {
+	ID             string                 `json:"id"`
+	JobID          string                 `json:"job_id"`
+	NodeID         string                 `json:"node_id"`
+	CorrelationKey string                 `json:"correlation_key"`
+	ApproverType   ApproverType           `json:"approver_type"`
+	ApproverID     string                 `json:"approver_id,omitempty"`
+	Role           string                 `json:"role,omitempty"`
+	Title          string                 `json:"title"`
+	Description    string                 `json:"description"`
+	Payload        map[string]interface{} `json:"payload,omitempty"`
+	Status         Decision               `json:"status"`
+	ApproverResp   *ApprovalResponse      `json:"approver_response,omitempty"`
+	ExpiresAt      *time.Time             `json:"expires_at,omitempty"`
+	CreatedAt      time.Time              `json:"created_at"`
+	UpdatedAt      time.Time              `json:"updated_at"`
+}
+
+// ApprovalResponse 审批响应
+type ApprovalResponse struct {
+	Decision     Decision  `json:"decision"`
+	ApproverID   string    `json:"approver_id"`
+	ApproverName string    `json:"approver_name"`
+	Comment      string    `json:"comment,omitempty"`
+	DelegatedTo  string    `json:"delegated_to,omitempty"`
+	RespondedAt  time.Time `json:"responded_at"`
+}
+
+// ApprovalStore 审批存储接口
+type ApprovalStore interface {
+	// Create 创建审批请求
+	Create(ctx context.Context, req *ApprovalRequest) error
+	// GetByID 根据 ID 获取审批请求
+	GetByID(ctx context.Context, id string) (*ApprovalRequest, error)
+	// GetByJobID 根据 Job ID 获取所有审批请求
+	GetByJobID(ctx context.Context, jobID string) ([]*ApprovalRequest, error)
+	// GetPending 获取所有待审批请求
+	GetPending(ctx context.Context) ([]*ApprovalRequest, error)
+	// GetPendingByApprover 根据审批人获取待审批请求
+	GetPendingByApprover(ctx context.Context, approverID string) ([]*ApprovalRequest, error)
+	// Complete 完成审批请求
+	Complete(ctx context.Context, id string, resp *ApprovalResponse) error
+	// Expire 标记审批请求已过期
+	Expire(ctx context.Context, id string) error
+}

--- a/internal/api/http/handler.go
+++ b/internal/api/http/handler.go
@@ -2658,9 +2658,9 @@ func (h *Handler) CreateApproval(ctx context.Context, c *app.RequestContext) {
 		ver := len(events)
 		ev, err := jobstore.NewApprovalRequestedEvent(req.JobID, approvalID, req.NodeID, req.CorrelationKey, req.ApproverType, req.Title, req.Description, req.Payload, expiresAt)
 		if err == nil {
-		if _, err := h.jobEventStore.Append(ctx, req.JobID, ver, *ev); err != nil {
-			hlog.CtxErrorf(ctx, "CreateApproval Append: %v", err)
-		}
+			if _, err := h.jobEventStore.Append(ctx, req.JobID, ver, *ev); err != nil {
+				hlog.CtxErrorf(ctx, "CreateApproval Append: %v", err)
+			}
 		}
 	}
 	c.JSON(consts.StatusCreated, map[string]interface{}{

--- a/internal/api/http/handler.go
+++ b/internal/api/http/handler.go
@@ -49,6 +49,7 @@ import (
 	"github.com/prometheus/common/expfmt"
 
 	"rag-platform/internal/agent"
+	"rag-platform/internal/agent/approval"
 	"rag-platform/internal/agent/instance"
 	"rag-platform/internal/agent/job"
 	"rag-platform/internal/agent/messaging"
@@ -127,6 +128,8 @@ type Handler struct {
 	observabilityReader job.ObservabilityReader
 	// rbac RBAC 权限检查器（可选）
 	rbac auth.RBACChecker
+	// approvalStore 审批存储（可选）；非 nil 时启用审批 API
+	approvalStore approval.ApprovalStore
 }
 
 // NewHandler 创建新的 HTTP 处理器
@@ -228,6 +231,11 @@ func (h *Handler) SetObservabilityReader(r job.ObservabilityReader) {
 // SetRBAC 设置 RBAC 权限检查器
 func (h *Handler) SetRBAC(rbac auth.RBACChecker) {
 	h.rbac = rbac
+}
+
+// SetApprovalStore 设置审批存储；非 nil 时启用审批 API
+func (h *Handler) SetApprovalStore(store approval.ApprovalStore) {
+	h.approvalStore = store
 }
 
 // getJobAndCheckTenant 按 jobID 取 Job 并校验当前请求租户；不通过时写 404 并返回 (nil, false)
@@ -2585,4 +2593,223 @@ func (h *Handler) CheckPermission(ctx context.Context, c *app.RequestContext) {
 		return
 	}
 	c.JSON(consts.StatusOK, map[string]bool{"allowed": allowed})
+}
+
+// Approval HTTP Handlers
+
+// CreateApprovalRequest POST /api/approvals 请求体
+type CreateApprovalRequest struct {
+	JobID          string                 `json:"job_id" binding:"required"`
+	NodeID         string                 `json:"node_id" binding:"required"`
+	CorrelationKey string                 `json:"correlation_key" binding:"required"`
+	ApproverType   string                 `json:"approver_type"` // anyone | specific | role
+	ApproverID     string                 `json:"approver_id,omitempty"`
+	Role           string                 `json:"role,omitempty"`
+	Title          string                 `json:"title" binding:"required"`
+	Description    string                 `json:"description"`
+	Payload        map[string]interface{} `json:"payload,omitempty"`
+	ExpiresInHours int                    `json:"expires_in_hours"` // 0 表示不过期
+}
+
+// CreateApproval 创建审批请求
+func (h *Handler) CreateApproval(ctx context.Context, c *app.RequestContext) {
+	if h.approvalStore == nil {
+		c.JSON(consts.StatusServiceUnavailable, map[string]string{"error": "审批功能未启用"})
+		return
+	}
+	var req CreateApprovalRequest
+	if err := c.BindJSON(&req); err != nil {
+		c.JSON(consts.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	if req.ApproverType == "" {
+		req.ApproverType = "anyone"
+	}
+	approvalID := fmt.Sprintf("apr-%d", time.Now().UnixNano())
+	var expiresAt *time.Time
+	if req.ExpiresInHours > 0 {
+		t := time.Now().Add(time.Duration(req.ExpiresInHours) * time.Hour)
+		expiresAt = &t
+	}
+	approvalReq := &approval.ApprovalRequest{
+		ID:             approvalID,
+		JobID:          req.JobID,
+		NodeID:         req.NodeID,
+		CorrelationKey: req.CorrelationKey,
+		ApproverType:   approval.ApproverType(req.ApproverType),
+		ApproverID:     req.ApproverID,
+		Role:           req.Role,
+		Title:          req.Title,
+		Description:    req.Description,
+		Payload:        req.Payload,
+		Status:         approval.DecisionPending,
+		ExpiresAt:      expiresAt,
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+	if err := h.approvalStore.Create(ctx, approvalReq); err != nil {
+		hlog.CtxErrorf(ctx, "CreateApproval: %v", err)
+		c.JSON(consts.StatusInternalServerError, map[string]string{"error": "创建审批请求失败"})
+		return
+	}
+	// 写入 job event
+	if h.jobEventStore != nil {
+		events, _, _ := h.jobEventStore.ListEvents(ctx, req.JobID)
+		ver := len(events)
+		ev, err := jobstore.NewApprovalRequestedEvent(req.JobID, approvalID, req.NodeID, req.CorrelationKey, req.ApproverType, req.Title, req.Description, req.Payload, expiresAt)
+		if err == nil {
+			h.jobEventStore.Append(ctx, req.JobID, ver, *ev)
+		}
+	}
+	c.JSON(consts.StatusCreated, map[string]interface{}{
+		"id":      approvalID,
+		"job_id":  req.JobID,
+		"status":  "pending",
+		"message": "审批请求已创建",
+	})
+}
+
+// ListApprovals GET /api/approvals?job_id=&status=&approver_id=
+func (h *Handler) ListApprovals(ctx context.Context, c *app.RequestContext) {
+	if h.approvalStore == nil {
+		c.JSON(consts.StatusServiceUnavailable, map[string]string{"error": "审批功能未启用"})
+		return
+	}
+	jobID := string(c.Query("job_id"))
+	approverID := string(c.Query("approver_id"))
+	var approvals []*approval.ApprovalRequest
+	var err error
+	if jobID != "" {
+		approvals, err = h.approvalStore.GetByJobID(ctx, jobID)
+	} else if approverID != "" {
+		approvals, err = h.approvalStore.GetPendingByApprover(ctx, approverID)
+	} else {
+		approvals, err = h.approvalStore.GetPending(ctx)
+	}
+	if err != nil {
+		hlog.CtxErrorf(ctx, "ListApprovals: %v", err)
+		c.JSON(consts.StatusInternalServerError, map[string]string{"error": "查询审批请求失败"})
+		return
+	}
+	c.JSON(consts.StatusOK, map[string]interface{}{
+		"approvals": approvals,
+		"count":     len(approvals),
+	})
+}
+
+// GetApproval GET /api/approvals/:id
+func (h *Handler) GetApproval(ctx context.Context, c *app.RequestContext) {
+	if h.approvalStore == nil {
+		c.JSON(consts.StatusServiceUnavailable, map[string]string{"error": "审批功能未启用"})
+		return
+	}
+	id := c.Param("id")
+	if id == "" {
+		c.JSON(consts.StatusBadRequest, map[string]string{"error": "id is required"})
+		return
+	}
+	req, err := h.approvalStore.GetByID(ctx, id)
+	if err != nil {
+		hlog.CtxErrorf(ctx, "GetApproval %s: %v", id, err)
+		c.JSON(consts.StatusInternalServerError, map[string]string{"error": "查询审批请求失败"})
+		return
+	}
+	if req == nil {
+		c.JSON(consts.StatusNotFound, map[string]string{"error": "审批请求不存在"})
+		return
+	}
+	c.JSON(consts.StatusOK, req)
+}
+
+// ApprovalActionRequest POST /api/approvals/:id/approve 或 /reject 请求体
+type ApprovalActionRequest struct {
+	ApproverID   string `json:"approver_id" binding:"required"`
+	ApproverName string `json:"approver_name"`
+	Comment      string `json:"comment,omitempty"`
+	DelegatedTo  string `json:"delegated_to,omitempty"`
+}
+
+// ApproveApproval POST /api/approvals/:id/approve
+func (h *Handler) ApproveApproval(ctx context.Context, c *app.RequestContext) {
+	h.handleApprovalAction(ctx, c, approval.DecisionApproved)
+}
+
+// RejectApproval POST /api/approvals/:id/reject
+func (h *Handler) RejectApproval(ctx context.Context, c *app.RequestContext) {
+	h.handleApprovalAction(ctx, c, approval.DecisionRejected)
+}
+
+func (h *Handler) handleApprovalAction(ctx context.Context, c *app.RequestContext, decision approval.Decision) {
+	if h.approvalStore == nil {
+		c.JSON(consts.StatusServiceUnavailable, map[string]string{"error": "审批功能未启用"})
+		return
+	}
+	id := c.Param("id")
+	if id == "" {
+		c.JSON(consts.StatusBadRequest, map[string]string{"error": "id is required"})
+		return
+	}
+	var req ApprovalActionRequest
+	if err := c.BindJSON(&req); err != nil {
+		c.JSON(consts.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	existing, err := h.approvalStore.GetByID(ctx, id)
+	if err != nil {
+		hlog.CtxErrorf(ctx, "handleApprovalAction get %s: %v", id, err)
+		c.JSON(consts.StatusInternalServerError, map[string]string{"error": "查询审批请求失败"})
+		return
+	}
+	if existing == nil {
+		c.JSON(consts.StatusNotFound, map[string]string{"error": "审批请求不存在"})
+		return
+	}
+	if existing.Status != approval.DecisionPending {
+		c.JSON(consts.StatusConflict, map[string]string{"error": fmt.Sprintf("审批请求状态已是 %s", existing.Status)})
+		return
+	}
+	resp := &approval.ApprovalResponse{
+		Decision:     decision,
+		ApproverID:   req.ApproverID,
+		ApproverName: req.ApproverName,
+		Comment:      req.Comment,
+		DelegatedTo:  req.DelegatedTo,
+		RespondedAt:  time.Now(),
+	}
+	if err := h.approvalStore.Complete(ctx, id, resp); err != nil {
+		hlog.CtxErrorf(ctx, "handleApprovalAction complete %s: %v", id, err)
+		c.JSON(consts.StatusInternalServerError, map[string]string{"error": "审批操作失败"})
+		return
+	}
+	// 写入 job event：先 append approval_completed，再 append wait_completed 触发 Job 继续
+	if h.jobEventStore != nil {
+		events, _, _ := h.jobEventStore.ListEvents(ctx, existing.JobID)
+		ver := len(events)
+		completedEv, _ := jobstore.NewApprovalCompletedEvent(existing.JobID, id, existing.NodeID, existing.CorrelationKey, string(decision), req.ApproverID, req.ApproverName, req.Comment, req.DelegatedTo)
+		if completedEv != nil {
+			h.jobEventStore.Append(ctx, existing.JobID, ver, *completedEv)
+			ver++
+		}
+		// 同时写入 wait_completed 让 Job 继续执行
+		waitPayload, _ := json.Marshal(map[string]interface{}{
+			"node_id":         existing.NodeID,
+			"correlation_key": existing.CorrelationKey,
+			"payload":         req.Comment,
+		})
+		waitEv := &jobstore.JobEvent{
+			JobID:   existing.JobID,
+			Type:    jobstore.WaitCompleted,
+			Payload: waitPayload,
+		}
+		h.jobEventStore.Append(ctx, existing.JobID, ver, *waitEv)
+		h.jobStore.UpdateStatus(ctx, existing.JobID, job.StatusPending)
+		if h.wakeupQueue != nil {
+			h.wakeupQueue.NotifyReady(ctx, existing.JobID)
+		}
+	}
+	c.JSON(consts.StatusOK, map[string]interface{}{
+		"id":       id,
+		"decision": decision,
+		"message":  "审批已完成",
+	})
 }

--- a/internal/api/http/handler.go
+++ b/internal/api/http/handler.go
@@ -2658,7 +2658,9 @@ func (h *Handler) CreateApproval(ctx context.Context, c *app.RequestContext) {
 		ver := len(events)
 		ev, err := jobstore.NewApprovalRequestedEvent(req.JobID, approvalID, req.NodeID, req.CorrelationKey, req.ApproverType, req.Title, req.Description, req.Payload, expiresAt)
 		if err == nil {
-			h.jobEventStore.Append(ctx, req.JobID, ver, *ev)
+		if _, err := h.jobEventStore.Append(ctx, req.JobID, ver, *ev); err != nil {
+			hlog.CtxErrorf(ctx, "CreateApproval Append: %v", err)
+		}
 		}
 	}
 	c.JSON(consts.StatusCreated, map[string]interface{}{
@@ -2787,8 +2789,12 @@ func (h *Handler) handleApprovalAction(ctx context.Context, c *app.RequestContex
 		ver := len(events)
 		completedEv, _ := jobstore.NewApprovalCompletedEvent(existing.JobID, id, existing.NodeID, existing.CorrelationKey, string(decision), req.ApproverID, req.ApproverName, req.Comment, req.DelegatedTo)
 		if completedEv != nil {
-			h.jobEventStore.Append(ctx, existing.JobID, ver, *completedEv)
-			ver++
+			newVer, err := h.jobEventStore.Append(ctx, existing.JobID, ver, *completedEv)
+			if err != nil {
+				hlog.CtxErrorf(ctx, "handleApprovalAction Append completed: %v", err)
+			} else {
+				ver = newVer
+			}
 		}
 		// 同时写入 wait_completed 让 Job 继续执行
 		waitPayload, _ := json.Marshal(map[string]interface{}{
@@ -2801,10 +2807,16 @@ func (h *Handler) handleApprovalAction(ctx context.Context, c *app.RequestContex
 			Type:    jobstore.WaitCompleted,
 			Payload: waitPayload,
 		}
-		h.jobEventStore.Append(ctx, existing.JobID, ver, *waitEv)
-		h.jobStore.UpdateStatus(ctx, existing.JobID, job.StatusPending)
+		if _, err := h.jobEventStore.Append(ctx, existing.JobID, ver, *waitEv); err != nil {
+			hlog.CtxErrorf(ctx, "handleApprovalAction Append wait_completed: %v", err)
+		}
+		if err := h.jobStore.UpdateStatus(ctx, existing.JobID, job.StatusPending); err != nil {
+			hlog.CtxErrorf(ctx, "handleApprovalAction UpdateStatus: %v", err)
+		}
 		if h.wakeupQueue != nil {
-			h.wakeupQueue.NotifyReady(ctx, existing.JobID)
+			if err := h.wakeupQueue.NotifyReady(ctx, existing.JobID); err != nil {
+				hlog.CtxErrorf(ctx, "handleApprovalAction NotifyReady: %v", err)
+			}
 		}
 	}
 	c.JSON(consts.StatusOK, map[string]interface{}{

--- a/internal/api/http/router.go
+++ b/internal/api/http/router.go
@@ -181,6 +181,16 @@ func (r *Router) Build(addr string, opts ...config.Option) *server.Hertz {
 		}
 	}
 
+	// HITL Approval API
+	approvals := api.Group("/approvals")
+	{
+		approvals.POST("", r.authChainWith(auth.PermissionJobCreate, r.handler.CreateApproval)...)
+		approvals.GET("", r.authChainWith(auth.PermissionJobView, r.handler.ListApprovals)...)
+		approvals.GET("/:id", r.authChainWith(auth.PermissionJobView, r.handler.GetApproval)...)
+		approvals.POST("/:id/approve", r.authChainWith(auth.PermissionJobCreate, r.handler.ApproveApproval)...)
+		approvals.POST("/:id/reject", r.authChainWith(auth.PermissionJobCreate, r.handler.RejectApproval)...)
+	}
+
 	// 2.0-M3: Forensics 查询类接口（实验能力，默认不暴露）
 	if r.forensicsExperimental {
 		forensics := api.Group("/forensics")

--- a/internal/runtime/jobstore/event.go
+++ b/internal/runtime/jobstore/event.go
@@ -104,6 +104,10 @@ const (
 	// 2.1: Evidence Export audit events
 	EvidenceExportRequested EventType = "evidence_export_requested" // 证据导出请求
 	EvidenceExportCompleted EventType = "evidence_export_completed" // 证据导出完成
+
+	// Phase 1 HITL Approval Engine: structured approval requests
+	ApprovalRequested EventType = "approval_requested" // 审批请求已创建
+	ApprovalCompleted EventType = "approval_completed" // 审批已完成（approved/rejected）
 )
 
 // JobWaitingPayload job_waiting 事件 payload 契约；只有携带相同 correlation_key 的 signal 才能解除该 block（design/runtime-contract.md）
@@ -382,6 +386,88 @@ func NewCheckpointSavedEvent(jobID, checkpointID, sessionID, cursor string, step
 	return &JobEvent{
 		JobID:     jobID,
 		Type:      CheckpointSaved,
+		Payload:   data,
+		CreatedAt: time.Now(),
+	}, nil
+}
+
+// ApprovalRequestedPayload approval_requested 事件 payload
+type ApprovalRequestedPayload struct {
+	ApprovalID     string                 `json:"approval_id"`     // 审批请求唯一 ID
+	JobID          string                 `json:"job_id"`          // 关联的 Job ID
+	NodeID         string                 `json:"node_id"`         // Wait 节点 ID
+	CorrelationKey string                 `json:"correlation_key"` // 用于与 Signal 匹配的键
+	ApproverType   string                 `json:"approver_type"`   // anyone | specific | role
+	ApproverID     string                 `json:"approver_id,omitempty"`
+	Role           string                 `json:"role,omitempty"`
+	Title          string                 `json:"title"`             // 审批标题
+	Description    string                 `json:"description"`       // 审批描述
+	Payload        map[string]interface{} `json:"payload,omitempty"` // 传递给审批人的上下文
+	ExpiresAt      *time.Time             `json:"expires_at,omitempty"`
+	CreatedAt      time.Time              `json:"created_at"`
+}
+
+// ApprovalCompletedPayload approval_completed 事件 payload
+type ApprovalCompletedPayload struct {
+	ApprovalID     string    `json:"approval_id"`
+	JobID          string    `json:"job_id"`
+	NodeID         string    `json:"node_id"`
+	CorrelationKey string    `json:"correlation_key"`
+	Decision       string    `json:"decision"` // approved | rejected | expired | delegated
+	ApproverID     string    `json:"approver_id,omitempty"`
+	ApproverName   string    `json:"approver_name,omitempty"`
+	Comment        string    `json:"comment,omitempty"`
+	DelegatedTo    string    `json:"delegated_to,omitempty"`
+	CompletedAt    time.Time `json:"completed_at"`
+}
+
+// NewApprovalRequestedEvent 创建 approval_requested 事件
+func NewApprovalRequestedEvent(jobID, approvalID, nodeID, correlationKey, approverType, title, description string, payload map[string]interface{}, expiresAt *time.Time) (*JobEvent, error) {
+	pl := ApprovalRequestedPayload{
+		ApprovalID:     approvalID,
+		JobID:          jobID,
+		NodeID:         nodeID,
+		CorrelationKey: correlationKey,
+		ApproverType:   approverType,
+		Title:          title,
+		Description:    description,
+		Payload:        payload,
+		ExpiresAt:      expiresAt,
+		CreatedAt:      time.Now(),
+	}
+	data, err := json.Marshal(pl)
+	if err != nil {
+		return nil, err
+	}
+	return &JobEvent{
+		JobID:     jobID,
+		Type:      ApprovalRequested,
+		Payload:   data,
+		CreatedAt: time.Now(),
+	}, nil
+}
+
+// NewApprovalCompletedEvent 创建 approval_completed 事件
+func NewApprovalCompletedEvent(jobID, approvalID, nodeID, correlationKey, decision, approverID, approverName, comment, delegatedTo string) (*JobEvent, error) {
+	pl := ApprovalCompletedPayload{
+		ApprovalID:     approvalID,
+		JobID:          jobID,
+		NodeID:         nodeID,
+		CorrelationKey: correlationKey,
+		Decision:       decision,
+		ApproverID:     approverID,
+		ApproverName:   approverName,
+		Comment:        comment,
+		DelegatedTo:    delegatedTo,
+		CompletedAt:    time.Now(),
+	}
+	data, err := json.Marshal(pl)
+	if err != nil {
+		return nil, err
+	}
+	return &JobEvent{
+		JobID:     jobID,
+		Type:      ApprovalCompleted,
 		Payload:   data,
 		CreatedAt: time.Now(),
 	}, nil


### PR DESCRIPTION
## Summary
- Implement Phase 1 of the HITL Approval Engine (issue #90)
- New `internal/agent/approval/` package with ApprovalRequest model and ApprovalStore interface
- In-memory MemStore implementation for testing/single-instance
- New event types: `approval_requested` and `approval_completed` in jobstore
- API endpoints: POST/GET /api/approvals, POST approve/reject
- Approval completion auto-appends wait_completed and resumes the job

## Test plan
- [x] make fmt-check passed
- [x] make vet passed
- [x] make test passed (full suite with race detector)
- [x] make build succeeded
- [x] Approval store tests: 4/4 passing

Made with [Cursor](https://cursor.com)