### PR TITLE
docs: add MCP integration guide + API reference + update quickstart

### DIFF
--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -235,6 +235,7 @@ go run main.go
 
 ## 下一步
 
+- [MCP Gateway 集成](../mcp/integration.md) — 使用 MCP Gateway 工具扩展 Agent 能力
 - [事件溯源概念](./concepts/event-sourcing.md) — 深入理解 Aetheris 的核心设计
 - [Code Review Agent 教程](./tutorials/code-review-agent.md) — 构建企业级代码审查 Agent
 - [Audit Agent 教程](./tutorials/audit-agent.md) — 构建合规审计 Agent

--- a/docs/mcp/integration.md
+++ b/docs/mcp/integration.md
@@ -1,0 +1,209 @@
+# MCP Gateway 集成指南
+
+> 本指南帮助你在 Aetheris 项目中集成并使用 MCP Gateway 工具。
+
+## 概述
+
+MCP Gateway 提供了四类可复用的 MCP 工具，可直接注册到 Aetheris 运行时：
+
+| 工具 | 包路径 | 用途 |
+|------|--------|------|
+| `mcp-github` | `tools/mcp-gateway/tools/mcp-github` | GitHub API 操作 |
+| `mcp-filesystem` | `tools/mcp-gateway/tools/mcp-filesystem` | 本地文件系统安全操作 |
+| `mcp-web-search` | `tools/mcp-gateway/tools/mcp-web-search` | 网页搜索与内容提取 |
+| `mcp-database` | `tools/mcp-gateway/tools/mcp-database` | 数据库查询 |
+
+## 快速集成
+
+### Step 1: 安装依赖
+
+```bash
+go get github.com/Colin4k1024/Aetheris/v2/tools/mcp-gateway/tools/mcp-github
+go get github.com/google/go-github/v45
+```
+
+### Step 2: 注册工具到 Registry
+
+```go
+import (
+    mcpgithub "github.com/Colin4k1024/Aetheris/v2/tools/mcp-gateway/tools/mcp-github"
+    "github.com/Colin4k1024/Aetheris/v2/internal/tool/registry"
+)
+
+reg := registry.GetGlobal()
+
+// 注册 GitHub MCP 工具
+githubTool := mcpgithub.NewGitHubTool(&mcpgithub.GitHubConfig{
+    Token: os.Getenv("GITHUB_TOKEN"),
+})
+reg.Register(githubTool)
+```
+
+### Step 3: 通过 MCP 服务器调用
+
+```go
+import (
+    "github.com/Colin4k1024/Aetheris/v2/internal/tool/mcp"
+    "github.com/Colin4k1024/Aetheris/v2/internal/tool/gatekeeper"
+)
+
+gk := gatekeeper.New(
+    gatekeeper.WithAllowedHosts([]string{"api.github.com"}),
+    gatekeeper.WithTypeValidation(true),
+)
+
+server := mcp.NewMCPServer(reg, gk)
+
+// 列出所有可用工具
+tools, _ := server.ListTools(ctx)
+for _, t := range tools {
+    fmt.Println(t.Name, "-", t.Description)
+}
+
+// 通过 MCP 协议调用工具
+result, _ := server.CallTool(ctx, "mcp-github", map[string]any{
+    "action": "search_repos",
+    "query":  "agent runtime golang",
+    "limit":  5,
+})
+fmt.Println(result)
+```
+
+## MCP Gateway 工具详解
+
+### GitHub Tool (`mcp-github`)
+
+```go
+githubTool := mcpgithub.NewGitHubTool(&mcpgithub.GitHubConfig{
+    Token:   os.Getenv("GITHUB_TOKEN"),
+    BaseURL: "https://api.github.com",  // 可选：GitHub Enterprise
+    Timeout: 30 * time.Second,
+})
+```
+
+**可用 action**:
+
+| action | 参数 | 说明 |
+|--------|------|------|
+| `search_repos` | `query`, `limit` | 搜索仓库 |
+| `get_issue` | `owner`, `repo`, `issue_number` | 获取 Issue |
+| `create_issue` | `owner`, `repo`, `title`, `body` | 创建 Issue |
+| `list_pulls` | `owner`, `repo`, `state`, `limit` | 列出 PRs |
+| `get_file` | `owner`, `repo`, `path`, `ref` | 获取文件内容 |
+| `create_pr` | `owner`, `repo`, `title`, `body`, `head`, `base` | 创建 PR |
+
+**示例**:
+
+```go
+// 搜索仓库
+result, _ := githubTool.Execute(ctx, map[string]any{
+    "action": "search_repos",
+    "query":  "aetheris agent runtime",
+    "limit":  10,
+})
+
+// 创建 Issue
+result, _ := githubTool.Execute(ctx, map[string]any{
+    "action":      "create_issue",
+    "owner":       "Colin4k1024",
+    "repo":        "Aetheris",
+    "title":       "Bug: tool fails on large files",
+    "body":        "Steps to reproduce...",
+})
+```
+
+### Filesystem Tool (`mcp-filesystem`)
+
+```go
+import mcpfs "github.com/Colin4k1024/Aetheris/v2/tools/mcp-gateway/tools/mcp-filesystem"
+
+fsTool := mcpfs.NewFilesystemTool(&mcpfs.FilesystemConfig{
+    RootDir:     "/data",
+    AllowedPaths: []string{"/data/docs", "/data/uploads"},
+    MaxFileSize: 10 * 1024 * 1024, // 10MB
+})
+```
+
+**可用 action**:
+
+| action | 参数 | 说明 |
+|--------|------|------|
+| `read_file` | `path` | 读取文件 |
+| `write_file` | `path`, `content` | 写入文件 |
+| `list_dir` | `path` | 列出目录 |
+| `search_files` | `query`, `path` | 搜索文件 |
+
+### Web Search Tool (`mcp-web-search`)
+
+```go
+import mcpsearch "github.com/Colin4k1024/Aetheris/v2/tools/mcp-gateway/tools/mcp-web-search"
+
+searchTool := mcpsearch.NewWebSearchTool(&mcpsearch.WebSearchConfig{
+    APIKey:  os.Getenv("SEARCH_API_KEY"),
+    Engine:  "google",
+    Timeout: 30 * time.Second,
+})
+```
+
+### Database Tool (`mcp-database`)
+
+```go
+import mcpdb "github.com/Colin4k1024/Aetheris/v2/tools/mcp-gateway/tools/mcp-database"
+
+dbTool := mcpdb.NewDatabaseTool(&mcpdb.DatabaseConfig{
+    DSN:     "postgres://user:pass@localhost:5432/db",
+    Driver:  "postgres",
+    Timeout: 30 * time.Second,
+})
+```
+
+## 通过 agents.yaml 配置
+
+在 `configs/agents.yaml` 中声明 MCP 工具：
+
+```yaml
+agents:
+  github_agent:
+    type: "react"
+    llm: "default"
+    tools:
+      - "mcp-github"
+    system_prompt: |
+      你是一个 GitHub 助手，可以搜索仓库、查看 Issue 和创建 PR。
+```
+
+## MCP 服务器传输模式
+
+### Stdio 模式（本地）
+
+适用于 CLI 工具和本地开发：
+
+```bash
+aetheris mcp-server --transport stdio
+```
+
+### HTTP + SSE 模式（生产）
+
+适用于 Web 服务：
+
+```go
+server := mcp.NewMCPServer(reg, gk)
+// 集成到 HTTP 路由
+http.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
+    server.HandleHTTP(w, r)
+})
+```
+
+## 最佳实践
+
+1. **始终配置 Gatekeeper**：限制允许的 hosts，防止 SSRF 攻击
+2. **使用环境变量存储 Token**：不要硬编码敏感信息
+3. **设置合理的 Timeout**：避免工具调用阻塞
+4. **错误处理**：检查 `ToolResult.Err` 字段
+
+## See Also
+
+- [MCP Implementation Guide](implementation.md) — MCP 协议内部实现
+- [MCP Security Guide](security-guide.md) — 安全配置
+- [Tools Registry](../../tools/mcp-gateway/registry.yaml) — 完整工具清单
+- [OpenAPI Spec](../../tools/mcp-gateway/openapi.yaml) — MCP Gateway API 规范

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,0 +1,243 @@
+# Aetheris API Reference
+
+> 面向 Aetheris v2.x 用户的 HTTP API 快速参考。完整契约见 [api-contract.md](api-contract.md)。
+
+## Base URL
+
+```
+http://localhost:8080/api
+```
+
+## 认证
+
+```bash
+# Header 认证（当前实现）
+Authorization: Bearer <token>
+```
+
+## Jobs API
+
+### 提交 Job
+
+```http
+POST /api/runs
+Content-Type: application/json
+
+{
+  "workflow_id": "agent_message",
+  "input": {
+    "agent_id": "refund-agent",
+    "message": "请退款订单 order-123"
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "job_id": "job-abc123",
+  "status": "pending",
+  "created_at": "2026-04-19T12:00:00Z"
+}
+```
+
+### 查询 Job 状态
+
+```http
+GET /api/jobs/:id
+```
+
+```json
+{
+  "job_id": "job-abc123",
+  "status": "parked",
+  "agent_id": "refund-agent",
+  "current_node": "wait_approval",
+  "created_at": "2026-04-19T12:00:00Z"
+}
+```
+
+**Job Status 枚举:** `pending` | `running` | `parked` | `completed` | `failed` | `cancelled`
+
+### 发送 Signal（唤醒 Parked Job）
+
+```http
+POST /api/jobs/:id/signal
+Content-Type: application/json
+
+{
+  "correlation_key": "approval-abc123",
+  "payload": {
+    "approved": true,
+    "reason": "客户投诉合理"
+  }
+}
+```
+
+### 获取执行 Trace
+
+```http
+GET /api/jobs/:id/trace
+```
+
+```json
+{
+  "job_id": "job-abc123",
+  "timeline": [
+    {"time": "12:00:00", "event": "JobCreated"},
+    {"time": "12:00:05", "event": "StepStarted", "node": "query_order"},
+    {"time": "12:00:10", "event": "ToolCompleted", "node": "query_order"},
+    {"time": "12:00:15", "event": "JobParked", "node": "wait_approval", "correlation_key": "approval-abc123"},
+    {"time": "15:12:30", "event": "SignalReceived", "payload": {"approved": true}},
+    {"time": "15:12:35", "event": "StepStarted", "node": "send_refund"},
+    {"time": "15:12:40", "event": "JobCompleted"}
+  ]
+}
+```
+
+### 获取 Replay 数据
+
+```http
+GET /api/jobs/:id/replay
+```
+
+### 停止 Job
+
+```http
+POST /api/jobs/:id/stop
+```
+
+### 获取 Job 事件流
+
+```http
+GET /api/jobs/:id/events
+```
+
+## Agents API
+
+### 创建 Agent
+
+```http
+POST /api/agents
+Content-Type: application/json
+
+{
+  "name": "refund-agent",
+  "description": "退款审批 Agent",
+  "type": "react",
+  "llm": "default",
+  "tools": ["query_order", "send_refund"]
+}
+```
+
+### 列出 Agents
+
+```http
+GET /api/agents
+```
+
+### 获取 Agent 状态
+
+```http
+GET /api/agents/:id/state
+```
+
+### 列出 Agent 的 Jobs
+
+```http
+GET /api/agents/:id/jobs?status=running
+```
+
+## Documents API
+
+### 上传文档
+
+```http
+POST /api/documents/upload
+Content-Type: multipart/form-data
+
+file: <binary>
+knowledge_id: "kb-123"
+```
+
+### 列出文档
+
+```http
+GET /api/documents?knowledge_id=kb-123
+```
+
+## MCP Tool API
+
+> 通过 MCP Gateway 注册的工具通过 MCP 协议调用，不走 REST API。
+
+```bash
+# 通过 MCP 协议列出工具
+mcp__tools__list
+
+# 通过 MCP 协议调用工具
+mcp__tools__call
+{
+  "name": "mcp-github",
+  "arguments": {
+    "action": "search_repos",
+    "query": "aetheris golang",
+    "limit": 5
+  }
+}
+```
+
+## System API
+
+### 健康检查
+
+```http
+GET /health
+```
+
+### 版本信息
+
+```http
+GET /api/version
+```
+
+## 错误格式
+
+所有错误返回统一格式：
+
+```json
+{
+  "error": {
+    "code": "JOB_NOT_FOUND",
+    "message": "Job job-xxx not found",
+    "details": {}
+  }
+}
+```
+
+**常见错误码:**
+
+| Code | HTTP Status | 说明 |
+|------|-------------|------|
+| `JOB_NOT_FOUND` | 404 | Job 不存在 |
+| `AGENT_NOT_FOUND` | 404 | Agent 不存在 |
+| `INVALID_SIGNAL_KEY` | 400 | correlation_key 不匹配 |
+| `JOB_NOT_PARKED` | 400 | Job 未在 Parked 状态，无法 Signal |
+| `TOOL_NOT_FOUND` | 404 | 工具未注册 |
+| `TOOL_EXECUTION_ERROR` | 500 | 工具执行失败 |
+| `UNAUTHORIZED` | 401 | 未认证 |
+| `RATE_LIMITED` | 429 | 请求过于频繁 |
+
+## 速率限制
+
+| 端点 | 限制 |
+|------|------|
+| `POST /api/runs` | 100 req/min |
+| `POST /api/jobs/:id/signal` | 60 req/min |
+| `GET /api/jobs/:id/*` | 300 req/min |
+
+## See Also
+
+- [API Contract](api-contract.md) — 完整 API 契约与兼容性承诺
+- [Getting Started](../guides/get-started.md) — 端到端使用教程
+- [Observability](../guides/observability.md) — Trace 与监控


### PR DESCRIPTION
## Summary

- **New**:  — MCP Gateway 集成指南，覆盖 GitHub/Filesystem/Web Search/Database 工具的注册与调用
- **New**:  — 面向用户的 API 快速参考，含 curl 示例和错误码表
- **Update**:  — 在下一步部分添加 MCP Gateway 链接

## Files Changed
-  (new, ~5600 chars)
-  (new, ~4100 chars)
-  (added 1 line)