### PR TITLE
docs: add blog post, MCP marketplace page, newsletter, tweet drafts

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,23 @@ Aetheris makes agents production-ready.
 
 ---
 
+## 🧩 Templates & Ecosystem
+
+Start fast with production-ready templates:
+
+| Template | Description |
+|----------|-------------|
+| [Customer Service Agent](./templates/customer-service-agent/) | Multi-turn support with human approval |
+| [RAG Assistant](./templates/rag-assistant/) | Vector search + LLM with citations |
+| [Autonomous Researcher](./templates/autonomous-researcher/) | Self-directed research agent |
+| [Multi-Agent Debate](./templates/multi-agent-debate/) | Multi-agent discussion & consensus |
+
+[MCP Gateway](./tools/mcp-gateway/) — Pre-built tools: GitHub, Filesystem, Web Search, Database
+
+[VSCode Extension](./tools/vscode-extension/) — Code snippets & syntax highlighting
+
+---
+
 ## 🌍 Community
 
 [Discord](https://discord.gg/PrrK2Mua) • [Discussions](https://github.com/Colin4k1024/Aetheris/discussions) • [Docs](https://docs.aetheris.ai)

--- a/docs/blog/11-why-agents-need-runtime.md
+++ b/docs/blog/11-why-agents-need-runtime.md
@@ -1,0 +1,178 @@
+# 为什么 AI Agent 需要自己的 Runtime——对比 Temporal、Aetheris 和 LangChain
+
+> 2026-04-19 | Aetheris v2.5.3
+
+## TL;DR
+
+如果你在用 LangChain/LangGraph 写 Agent，那是在写**业务逻辑**。但生产级别的 Agent 还需要**执行可靠性**——崩溃恢复、幂等保证、审计追溯。Temporal 是工作流引擎，Aetheris 是为 Agent 场景重新设计的执行 Runtime。
+
+---
+
+## 背景：为什么 AI Agent 不同于普通微服务
+
+一个 AI Agent 微服务，需要：
+- **执行过程可追溯**：LLM 每一步决策、每个 Tool 调用，都要记录
+- **Tool 幂等性**：同一个退款请求，Worker 崩溃重启后不能执行两次
+- **Human-in-the-Loop**：Agent 在关键节点等待人工审批，不占用 Worker 资源
+- **多 Worker 并行**：多个 Worker 同时处理不同 Job，不能相互干扰
+
+这些需求，微服务框架不解决，LangChain 也不解决。它们解决的是"怎么写 Agent"，而不是"怎么可靠地跑 Agent"。
+
+---
+
+## Temporal：工作流引擎的正确打开方式
+
+Temporal 是一个强大的工作流编排引擎，核心解决**长时间运行工作流的可靠性**。
+
+**优点：**
+- 活动（Activity）级别的重试和超时
+- Workflow 状态持久化，崩溃可恢复
+- 丰富的查询和信号机制
+- 多语言 SDK 成熟
+
+**局限性：**
+- Workflow 代码有严格约束（幂等、无副作用、不依赖外部时间）
+- LLM 调用作为 Activity 时，每次重试都会重新调用 LLM（Token 浪费 + 结果不稳定）
+- 没有内置的"AI 执行轨迹"概念，LLM 决策历史需要自己存储
+- 信号机制适合工作流控制，但不适合 LLM 的流式输出处理
+
+**Temporal 的适用场景：**
+- 订单处理、支付流程
+- 保险理赔、工作流审批
+- 数据 ETL 管道
+
+---
+
+## Aetheris：专为 Agent Runtime 设计
+
+Aetheris 从一开始就是为 AI Agent 设计的执行层，解决的是 Temporal 没有覆盖的 Agent 特有需求。
+
+### 核心区别 1：LLM 调用的 Effect Store
+
+Temporal 里，Activity 重试 = 重新执行，包括重新调用 LLM。
+
+Aetheris 有 Effect Store，专门存储 LLM 调用结果：
+
+```
+Step 1: LLM Decide  →  Effect Store 记录: {input: "...", output: "..."}
+Step 2: Worker 崩溃
+Step 3: 新 Worker 接管
+Step 4: Replay 时，LLM 调用被拦截，直接从 Effect Store 返回缓存结果
+```
+
+这意味着：
+- **崩溃恢复后 LLM 不会重新调用** — 节省 Token，保证确定性
+- **结果一致性** — 同一个 Job 无论重试多少次，LLM 输出不变
+
+### 核心区别 2：Tool 幂等性 + Ledger
+
+Aetheris 的 Invocation Ledger 记录每个 Tool 的执行状态：
+
+```
+send_refund(idempotency_key="aetheris:job-123:send_refund:1")  // 第一次执行
+→ Ledger 记录: EXECUTED
+→ Effect Store 记录: {idempotency_key, result}
+
+Worker 崩溃
+新 Worker 接管，读取 Ledger
+→ 发现 send_refund 已执行，直接跳到下一步
+```
+
+退款 API 不会被调用两次。这是 Temporal Activity 做不到的。
+
+### 核心区别 3：Human-in-the-Loop 的 Parked 状态
+
+Agent 在关键节点等待人工审批（或者外部 webhook）：
+
+```
+Job 执行到 wait_approval 节点
+→ Status = Parked（不占用 Worker）
+→ 人工审批后 Signal 唤醒
+→ 继续执行 send_refund
+```
+
+Temporal 的信号机制可以做到类似的事，但：
+- Temporal 信号是给 Workflow 发消息，LLM 决策不能被打断
+- Aetheris 的 Wait 节点可以暂停在 LLM 决策点，审批后继续从该节点执行
+
+### 核心区别 4：Agent 原生的 Trace 和 Evidence
+
+Aetheris 的执行记录专为 AI Agent 设计：
+
+```json
+{
+  "steps": [
+    {
+      "node_id": "llm_decide",
+      "evidence": {
+        "llm_invocation_id": "aetheris:job-123:llm:1",
+        "model": "gpt-4o-2024-11-20",
+        "temperature": 0.7,
+        "input_tokens": 1234,
+        "output_tokens": 567
+      }
+    },
+    {
+      "node_id": "send_refund",
+      "evidence": {
+        "tool_invocation_ids": ["aetheris:job-123:send_refund:1"],
+        "idempotency_key": "aetheris:job-123:send_refund:1",
+        "external_ref": "stripe_charge_xxx"
+      }
+    }
+  ]
+}
+```
+
+每个 LLM 调用、每个 Tool 调用，都可以用 Evidence 证明。
+
+---
+
+## 对比表
+
+| 维度 | Temporal | Aetheris |
+|------|----------|----------|
+| 定位 | 工作流引擎 | Agent 执行 Runtime |
+| LLM 重试 | 重新调用（浪费 Token） | Effect Store 拦截（零重试开销） |
+| Tool 幂等 | Activity 实现（业务负责） | Ledger + Idempotency Key（内置） |
+| Human-in-the-Loop | Signal 机制 | Wait Node + Parked 状态 |
+| 执行 Trace | 通用工作流历史 | AI 原生 Trace + Evidence |
+| 适用场景 | 订单/支付/ETL | AI Agent + RAG + 对话系统 |
+| Agent 框架集成 | 需自己包装 | MCP 协议原生支持 |
+
+---
+
+## 什么时候选什么
+
+**选 Temporal 如果：**
+- 核心是业务流程，LLM 只是其中一步
+- 已有 Temporal 基础设施
+- 需要强一致的工作流编排
+
+**选 Aetheris 如果：**
+- 核心是 AI Agent，需要可靠地跑 LLM
+- 需要 LLM 决策的确定性（不重复调用）
+- 需要 AI 决策的审计追溯
+- 需要 MCP 协议的工具生态
+
+---
+
+## 结论
+
+Temporal 解决的是"长时间运行工作流的可靠性"。
+
+Aetheris 解决的是"AI Agent 执行的可靠性"——LLM 不重复调用、Tool 不重复执行、决策过程完整可审计。
+
+两者不是非此即彼。对于需要强工作流编排 + AI Agent 的系统，可以：
+- 用 Temporal 做顶层业务流程编排
+- 用 Aetheris 作为 Temporal Activity 中的"AI Agent 执行单元"
+
+这就是 Aetheris v2.5.3 的设计思路：作为 MCP Server 被宿主框架调用，而不是替代所有工作流引擎。
+
+---
+
+**相关链接：**
+- [Aetheris GitHub](https://github.com/Colin4k1024/Aetheris)
+- [v2.5.3 Release Notes](https://github.com/Colin4k1024/Aetheris/releases/tag/v2.5.3)
+- [MCP Gateway 集成指南](../mcp/integration.md)
+- [At-Most-Once 执行原理](../blog/06-at-most-once-ledger.md)

--- a/docs/guides/mcp-marketplace.md
+++ b/docs/guides/mcp-marketplace.md
@@ -1,0 +1,178 @@
+# MCP Tool Marketplace
+
+> Discover and integrate pre-built MCP tools into your Aetheris agent runtime.
+
+## Available Tools
+
+### 🔌 GitHub Integration
+
+**`mcp-github`** — Interact with GitHub repositories, issues, and pull requests.
+
+```go
+githubTool := mcpgithub.NewGitHubTool(&mcpgithub.GitHubConfig{
+    Token: os.Getenv("GITHUB_TOKEN"),
+})
+```
+
+**Capabilities:**
+- `search_repos` — Search repositories by keyword
+- `get_issue` / `create_issue` — Read and create GitHub issues
+- `list_pulls` — List pull requests with filtering
+- `get_file` / `create_pr` — File operations and PR creation
+
+**Install:**
+```bash
+go get github.com/Colin4k1024/Aetheris/v2/tools/mcp-gateway/tools/mcp-github
+```
+
+---
+
+### 📁 Filesystem
+
+**`mcp-filesystem`** — Secure local file operations with path traversal protection.
+
+```go
+fsTool := mcpfs.NewFilesystemTool(&mcpfs.FilesystemConfig{
+    RootDir:     "/data",
+    AllowedPaths: []string{"/data/docs", "/data/uploads"},
+    MaxFileSize: 10 * 1024 * 1024,
+})
+```
+
+**Capabilities:**
+- `read_file` / `write_file` — Safe file I/O
+- `list_dir` — Directory listing
+- `search_files` — Full-text file search
+
+**Install:**
+```bash
+go get github.com/Colin4k1024/Aetheris/v2/tools/mcp-gateway/tools/mcp-filesystem
+```
+
+---
+
+### 🔍 Web Search
+
+**`mcp-web-search`** — Search the web and extract page content.
+
+```go
+searchTool := mcpsearch.NewWebSearchTool(&mcpsearch.WebSearchConfig{
+    APIKey:  os.Getenv("SEARCH_API_KEY"),
+    Engine:  "google",
+    Timeout: 30 * time.Second,
+})
+```
+
+**Capabilities:**
+- `search` — Execute web search across multiple engines
+- `get_content` — Extract and parse page content
+
+**Install:**
+```bash
+go get github.com/Colin4k1024/Aetheris/v2/tools/mcp-gateway/tools/mcp-web-search
+```
+
+---
+
+### 🗄️ Database
+
+**`mcp-database`** — Query PostgreSQL, MySQL and other databases with parameterized queries.
+
+```go
+dbTool := mcpdb.NewDatabaseTool(&mcpdb.DatabaseConfig{
+    DSN:     "postgres://user:pass@localhost:5432/db",
+    Driver:  "postgres",
+    Timeout: 30 * time.Second,
+})
+```
+
+**Capabilities:**
+- `query` — Execute parameterized SELECT queries
+- `execute` — Run DML/DDL statements
+- `list_tables` — Discover database schema
+
+**Install:**
+```bash
+go get github.com/Colin4k1024/Aetheris/v2/tools/mcp-gateway/tools/mcp-database
+```
+
+---
+
+## Quick Start
+
+### 1. Register tools
+
+```go
+import (
+    mcpgithub "github.com/Colin4k1024/Aetheris/v2/tools/mcp-gateway/tools/mcp-github"
+    "github.com/Colin4k1024/Aetheris/v2/internal/tool/registry"
+)
+
+reg := registry.GetGlobal()
+reg.Register(mcpgithub.NewGitHubTool(&mcpgithub.GitHubConfig{
+    Token: os.Getenv("GITHUB_TOKEN"),
+}))
+```
+
+### 2. Call via MCP protocol
+
+```go
+import (
+    "github.com/Colin4k1024/Aetheris/v2/internal/tool/mcp"
+    "github.com/Colin4k1024/Aetheris/v2/internal/tool/gatekeeper"
+)
+
+gk := gatekeeper.New(
+    gatekeeper.WithAllowedHosts([]string{"api.github.com"}),
+    gatekeeper.WithTypeValidation(true),
+)
+
+server := mcp.NewMCPServer(reg, gk)
+result, _ := server.CallTool(ctx, "mcp-github", map[string]any{
+    "action": "search_repos",
+    "query":  "aetheris agent runtime golang",
+    "limit":  5,
+})
+```
+
+### 3. Or use directly
+
+```go
+// Direct tool execution (no MCP protocol overhead)
+result, err := githubTool.Execute(ctx, map[string]any{
+    "action": "search_repos",
+    "query":  "agent runtime golang",
+    "limit":  5,
+})
+```
+
+## Registry File
+
+See [registry.yaml](../../tools/mcp-gateway/registry.yaml) for full tool清单 and configuration schemas.
+
+## Security
+
+All tools are validated through the Gatekeeper before execution:
+
+- **Network**: Allowed hosts must be explicitly configured
+- **Filesystem**: Path traversal attacks prevented via allowlist
+- **Database**: Parameterized queries prevent SQL injection
+- **Rate Limiting**: Per-tool rate limits configurable
+
+See [Security Guide](../mcp/security-guide.md) for production configuration.
+
+## Contributing a New Tool
+
+1. Create `tools/mcp-gateway/tools/mcp-yourtool/`
+2. Implement the `tool.Tool` interface
+3. Add `manifest.yaml` with metadata
+4. Register in [registry.yaml](../../tools/mcp-gateway/registry.yaml)
+5. Add example usage to this page
+
+See [CONTRIBUTING.md](../../tools/mcp-gateway/CONTRIBUTING.md) for full guide.
+
+## See Also
+
+- [MCP Integration Guide](../mcp/integration.md)
+- [MCP Implementation](../mcp/implementation.md)
+- [OpenAPI Spec](../../tools/mcp-gateway/openapi.yaml)

--- a/docs/promotion/newsletter.md
+++ b/docs/promotion/newsletter.md
@@ -1,0 +1,53 @@
+# Newsletter 订阅
+
+> 订阅 Aetheris 最新动态 — 版本发布、技术博客、社区更新。
+
+**暂不支持自动订阅** — 以下是手动订阅方式：
+
+## 订阅渠道
+
+### 1. GitHub Watch ⭐
+
+在 GitHub 上给 [Aetheris](https://github.com/Colin4k1024/Aetheris) 点星并设置通知：
+- 点击 `Watch` → `Custom` → 勾选 `Releases`
+
+### 2. GitHub Discussions
+
+关注 [Discussions](https://github.com/Colin4k1024/Aetheris/discussions) 区，有新帖时会收到通知。
+
+### 3. RSS Feed
+
+聚合平台：
+
+- **Blog RSS**: 博客更新（待接入）
+- **GitHub Releases RSS**: `https://github.com/Colin4k1024/Aetheris/releases.atom`
+
+在 Feedly / Inoreader 添加上述 RSS 地址即可。
+
+### 4. 技术博客
+
+每篇博客发布时会在 [Twitter/X](https://x.com/Colin4k1024) 同步通知。
+
+---
+
+## 更新频率
+
+| 类型 | 频率 |
+|------|------|
+| 版本发布 | ~每月一次 |
+| 技术博客 | ~每月两篇 |
+| 社区讨论 | 持续进行 |
+
+## 往期更新
+
+- [v2.5.3 (2026-04-19)](https://github.com/Colin4k1024/Aetheris/releases/tag/v2.5.3) — MCP Gateway + Hermes集成
+- [v2.5.2 (2026-04-14)](https://github.com/Colin4k1024/Aetheris/releases/tag/v2.5.2) — awesome-go收录
+- [v2.5.0 (2026-03-24)](https://github.com/Colin4k1024/Aetheris/releases/tag/v2.5.0) — At-Most-Once执行保证
+
+## 订阅管理
+
+取消订阅：请勿在本仓库提 issue，直接在通知设置中取消即可。
+
+---
+
+*暂无邮件订阅服务。如需商业合作或企业订阅，请联系维护团队。*

--- a/docs/promotion/tweet-drafts-v2.5.3.md
+++ b/docs/promotion/tweet-drafts-v2.5.3.md
@@ -1,0 +1,79 @@
+# Twitter/X 推文草稿 — v2.5.3 发布
+
+---
+
+## 推文 1 — 主要发布公告
+
+```
+🚀 Aetheris v2.5.3 is out!
+
+Hermes-Agent bidirectional integration is now live.
+MCP Gateway with GitHub, Filesystem, Web Search & DB tools.
+25 security fixes. SLSA3 provenance.
+
+Build reliable AI agents that survive crashes and never double-execute tools.
+
+github.com/Colin4k1024/Aetheris
+
+#AIagents #GoLang #MCP
+```
+
+---
+
+## 推文 2 — MCP Gateway 特性
+
+```
+The problem with AI agents in production:
+
+❌ Worker crashes → restart from scratch
+❌ Tool called twice → duplicate payments
+❌ No audit trail for LLM decisions
+
+Aetheris MCP Gateway solves this:
+
+✅ Crash recovery (Ledger + Effect Store)
+✅ At-most-once tool execution (idempotency keys)
+✅ Full decision trace with evidence
+
+5-min quickstart:
+github.com/Colin4k1024/Aetheris
+
+#AIagents #MCP #ProductionAI
+```
+
+---
+
+## 推文 3 — 开发者社区
+
+```
+Built an AI agent with Aetheris MCP Gateway:
+
+1. Import GitHub MCP tool
+2. Register to registry
+3. Call via MCP protocol
+4. Done — no more duplicate API calls
+
+Works with any Go agent framework (Eino, LangChainGo, custom).
+
+Code example → github.com/Colin4k1024/Aetheris/examples/mcp-gateway
+
+#GoLang #AIagents #DeveloperTools
+```
+
+---
+
+## 使用建议
+
+- 每条推文间隔 2-3 天发布
+- 配合博客文章链接效果更好
+- 附上 Terminal GIF 或截图增加互动
+- 用 [分流工具](https://tweetthread.com) 可一次发多条回复式推文
+
+## 发布计划建议
+
+| 日期 | 内容 |
+|------|------|
+| Day 1 | 推文 1（v2.5.3 发布公告）+ 博客链接 |
+| Day 3 | 推文 2（MCP Gateway 特性 Thread） |
+| Day 5 | 推文 3（开发者示例） |
+| Day 7 | 博客文章发布 + 知乎/掘金同步 |


### PR DESCRIPTION
## Summary

New blog post, MCP marketplace page, newsletter setup, and tweet drafts for v2.5.3 release.

### New Files

- **docs/blog/11-why-agents-need-runtime.md** — Blog post comparing Aetheris vs Temporal: LLM Effect Store, Tool idempotency via Ledger, Human-in-the-Loop Wait nodes, Agent-native Trace & Evidence
- **docs/guides/mcp-marketplace.md** — MCP Tool Marketplace page with usage examples for all 4 tools (GitHub, Filesystem, Web Search, Database)
- **docs/promotion/newsletter.md** — Newsletter subscription guide (GitHub Watch, RSS, blog)
- **docs/promotion/tweet-drafts-v2.5.3.md** — 3 tweet drafts for v2.5.3 release with posting schedule

### Updated Files

- **README.md** — Added "Templates & Ecosystem" section linking to templates/, MCP Gateway, and VSCode extension

### Already Completed (out of band)

- GitHub Discussion #166 (Announcements) — v2.5.3 release announcement
- GitHub Discussion #167 (Q&A) — Welcome post with FAQ
