### PR TITLE
fix: add quotes in slsa-release.yml shell scripts (SC2086)

### DIFF
--- a/.github/workflows/slsa-release.yml
+++ b/.github/workflows/slsa-release.yml
@@ -50,7 +50,7 @@ jobs:
           echo "Artifacts to generate provenance for:"
           echo "---"
           for f in dist/*; do
-            echo "  - $(basename $f): $(file $f) ($(stat -f%z $f 2>/dev/null || stat -c%s $f) bytes)"
+            echo "  - $(basename "$f"): $(file "$f") ($(stat -f%z "$f" 2>/dev/null || stat -c%s "$f") bytes)"
           done
           echo "---"
           echo "subjects=$(find dist -type f -exec basename {} \; | tr '\n' ',')" >> $GITHUB_OUTPUT
@@ -100,7 +100,7 @@ jobs:
           echo ""
           echo "Generated artifacts:"
           for f in dist/*; do
-            echo "  - $(basename $f)"
+            echo "  - $(basename "$f")"
           done
           echo ""
           echo "Provenance attestation: slsa-attestations.intoto.jsonl"


### PR DESCRIPTION
Fix shellcheck SC2086: double quote variables to prevent globbing and word splitting in slsa-release.yml.

Changes:
- Line 53: `basename $f` → `basename "$f"`
- Line 103: `basename $f` → `basename "$f"`