### PR TITLE
fix: Session 1 runtime correctness bugs (replay, reclaim, terminal events)

### DIFF
--- a/internal/agent/job/reclaim.go
+++ b/internal/agent/job/reclaim.go
@@ -21,7 +21,10 @@ import (
 )
 
 // ReclaimOrphanedFromEventStore 以 event store 租约为准回收孤儿（design/runtime-contract.md §3）：
-// 仅当租约已过期且 Job 未处于 Blocked（JobWaiting，§2）时，将 metadata 中该 job 置回 Pending。返回回收数量。
+// Session1-3 fix: 使用 DeriveStatusFromEvents 判断 event stream 真实状态，按结果分流处理：
+//   - 事件流为 terminal (Completed/Failed/Cancelled)：同步 metadata 为对应终态，不重新入队。
+//   - 事件流为 Blocked (Waiting/Parked)：跳过，不重新入队。
+//   - 其余情况（Running/Pending）：metadata 置回 Pending 重新入队。
 func ReclaimOrphanedFromEventStore(ctx context.Context, metadata JobStore, eventStore jobstore.JobStore) (int, error) {
 	if metadata == nil || eventStore == nil {
 		return 0, nil
@@ -36,9 +39,23 @@ func ReclaimOrphanedFromEventStore(ctx context.Context, metadata JobStore, event
 		if err != nil {
 			continue
 		}
-		if IsJobBlocked(events) {
+		derived := DeriveStatusFromEvents(events)
+		switch derived {
+		case StatusCompleted, StatusFailed, StatusCancelled:
+			// 事件流已有终态事件，仅同步 metadata（不重新入队）
+			j, err := metadata.Get(ctx, jobID)
+			if err != nil || j == nil {
+				continue
+			}
+			if j.Status != derived {
+				_ = metadata.UpdateStatus(ctx, jobID, derived)
+			}
+			continue
+		case StatusWaiting, StatusParked:
+			// Job 处于 Blocked 状态，不回收
 			continue
 		}
+		// 事件流状态为 Running/Pending（租约已过期），回收到 Pending 重新执行
 		j, err := metadata.Get(ctx, jobID)
 		if err != nil || j == nil {
 			continue

--- a/internal/agent/replay/replay.go
+++ b/internal/agent/replay/replay.go
@@ -50,6 +50,10 @@ type ReplayContext struct {
 	ApprovedCorrelationKeys  map[string]struct{}            // wait_completed 中的 correlation_key 集合，供 CapabilityPolicyChecker 审批后放行（design/capability-policy.md）
 	// WorkingMemorySnapshot 最近一次 job_waiting 的 resumption_context.memory_snapshot.working_memory（AgentState JSON）；恢复时 Apply 到 Session（design/durable-memory-layer.md）
 	WorkingMemorySnapshot []byte
+	// PendingWaitNode 尚未收到 wait_completed 的等待节点 node_id（来自 job_waiting 事件）；
+	// 非空说明 job 正处于等待状态，runner 不应再次写入 job_waiting 事件（去重）。
+	// 收到 wait_completed 时清空。
+	PendingWaitNode string
 	// Phase 由事件流推导的执行阶段（plan 3.4），用于观测与「Agent 即长期进程」表述
 	Phase ExecutionPhase
 	// RecordedTime effect_id -> 记录的时间（UnixNano）；来自 timer_fired 事件，Replay 时仅注入（2.0 确定性）
@@ -72,6 +76,7 @@ const (
 	PhaseCompleted                // 已 job_completed
 	PhaseFailed                   // 已 job_failed
 	PhaseCancelled                // 已 job_cancelled
+	PhaseWaiting                  // 已 job_waiting，等待外部信号（未收到 wait_completed）
 )
 
 // ExecutionState 执行状态：由事件流（或 Checkpoint）推导，供 Advance 决定下一步；ReplayContext 为其一种实现（plan 3.1 A）
@@ -231,6 +236,10 @@ func (b *replayBuilder) BuildFromEvents(ctx context.Context, jobID string) (*Rep
 			if err != nil || len(p.ResumptionContext) == 0 {
 				continue
 			}
+			// Session1-2 fix: 记录等待节点，供 runner 检测重复 job_waiting
+			if p.NodeID != "" {
+				out.PendingWaitNode = p.NodeID
+			}
 			var resumption map[string]interface{}
 			if json.Unmarshal(p.ResumptionContext, &resumption) != nil {
 				continue
@@ -264,6 +273,8 @@ func (b *replayBuilder) BuildFromEvents(ctx context.Context, jobID string) (*Rep
 			out.CompletedNodeIDs[pl.NodeID] = struct{}{}
 			out.CursorNode = pl.NodeID
 			out.CompletedCommandIDs[pl.NodeID] = struct{}{}
+			// Session1-2 fix: wait_completed 到达，清除等待状态
+			out.PendingWaitNode = ""
 			if pl.CorrelationKey != "" {
 				out.ApprovedCorrelationKeys[pl.CorrelationKey] = struct{}{}
 			}
@@ -320,6 +331,9 @@ func (b *replayBuilder) BuildFromEvents(ctx context.Context, jobID string) (*Rep
 		out.Phase = PhaseFailed
 	case jobstore.JobCancelled:
 		out.Phase = PhaseCancelled
+	case jobstore.JobWaiting:
+		// Session1-2 fix: job_waiting 且尚未收到 wait_completed
+		out.Phase = PhaseWaiting
 	default:
 		if len(out.TaskGraphState) > 0 {
 			out.Phase = PhaseExecuting
@@ -419,6 +433,7 @@ func deserializeSnapshot(snapshotData []byte) (*ReplayContext, error) {
 		StateChangesByStep:       make(map[string][]StateChangeRecord),
 		ApprovedCorrelationKeys:  make(map[string]struct{}),
 		WorkingMemorySnapshot:    []byte(payload.WorkingMemorySnapshot),
+		PendingWaitNode:          payload.PendingWaitNode,
 		Phase:                    ExecutionPhase(payload.Phase),
 		RecordedTime:             payload.RecordedTime,
 		RecordedRandom:           make(map[string][]byte),
@@ -588,6 +603,10 @@ func (b *replayBuilder) applyIncrementalEvents(rc *ReplayContext, events []jobst
 			if err != nil || len(p.ResumptionContext) == 0 {
 				continue
 			}
+			// Session1-2 fix: 记录等待节点
+			if p.NodeID != "" {
+				rc.PendingWaitNode = p.NodeID
+			}
 			var resumption map[string]interface{}
 			if json.Unmarshal(p.ResumptionContext, &resumption) != nil {
 				continue
@@ -621,6 +640,8 @@ func (b *replayBuilder) applyIncrementalEvents(rc *ReplayContext, events []jobst
 			rc.CompletedNodeIDs[pl.NodeID] = struct{}{}
 			rc.CursorNode = pl.NodeID
 			rc.CompletedCommandIDs[pl.NodeID] = struct{}{}
+			// Session1-2 fix: 清除等待状态
+			rc.PendingWaitNode = ""
 			if pl.CorrelationKey != "" {
 				rc.ApprovedCorrelationKeys[pl.CorrelationKey] = struct{}{}
 			}
@@ -676,6 +697,9 @@ func (b *replayBuilder) applyIncrementalEvents(rc *ReplayContext, events []jobst
 		rc.Phase = PhaseFailed
 	case jobstore.JobCancelled:
 		rc.Phase = PhaseCancelled
+	case jobstore.JobWaiting:
+		// Session1-2 fix
+		rc.Phase = PhaseWaiting
 	default:
 		if len(rc.TaskGraphState) > 0 {
 			rc.Phase = PhaseExecuting
@@ -706,6 +730,7 @@ func SerializeReplayContext(rc *ReplayContext) ([]byte, error) {
 		StateChangesByStep:       make(map[string]json.RawMessage),
 		ApprovedCorrelationKeys:  make([]string, 0, len(rc.ApprovedCorrelationKeys)),
 		WorkingMemorySnapshot:    json.RawMessage(rc.WorkingMemorySnapshot),
+		PendingWaitNode:          rc.PendingWaitNode,
 		Phase:                    int(rc.Phase),
 		RecordedTime:             rc.RecordedTime,
 		RecordedRandom:           make(map[string]json.RawMessage),

--- a/internal/agent/runtime/executor/atomic_commit.go
+++ b/internal/agent/runtime/executor/atomic_commit.go
@@ -16,9 +16,9 @@ package executor
 
 import (
 	"context"
-	"time"
 
 	"github.com/Colin4k1024/Aetheris/v2/internal/runtime/jobstore"
+	"github.com/google/uuid"
 )
 
 // LedgerEventSink 写入 Ledger 原子性事件：ledger_acquired（执行权获取）和 ledger_committed（结果提交）
@@ -94,5 +94,5 @@ func DefaultAtomicCommit(ctx context.Context, ledger InvocationLedger, sink Ledg
 }
 
 func newInvocationID() string {
-	return "inv-" + time.Now().Format("20060102150405.000000000")
+	return "inv-" + uuid.NewString()
 }

--- a/internal/agent/runtime/executor/runner.go
+++ b/internal/agent/runtime/executor/runner.go
@@ -149,6 +149,7 @@ type PlanGeneratedSink interface {
 // resultType/reason 为 Phase A failed语义；仅 result_type==success 时 Replay 将节点视为完成
 // AppendStateCheckpointed 的 opts 可选携带 changed_keys、tool_side_effects、resource_refs 供 Trace UI「本步变更」展示
 // AppendJobWaiting 写入 job_waiting，表示 Job 在 Wait 节点挂起（design/job-state-machine.md）
+// AppendJobCompleted/AppendJobFailed 写入终态事件（Session1-4 fix）：必须在 UpdateStatus 前调用，确保事件流与 metadata 的写入顺序正确
 type NodeEventSink interface {
 	AppendNodeStarted(ctx context.Context, jobID string, nodeID string, attempt int, workerID string) error
 	// AppendNodeFinished 写入 node_finished；stepID 为空时用 nodeID；inputHash 非空时写入 payload 供 Replay 确定性判定（plan 3.3）
@@ -157,6 +158,10 @@ type NodeEventSink interface {
 	AppendStepCommitted(ctx context.Context, jobID string, nodeID string, stepID string, commandID string, idempotencyKey string) error
 	AppendStateCheckpointed(ctx context.Context, jobID string, nodeID string, stateBefore, stateAfter []byte, opts *StateCheckpointOpts) error
 	AppendJobWaiting(ctx context.Context, jobID string, nodeID string, waitKind, reason string, expiresAt time.Time, correlationKey string, resumptionContext []byte) error
+	// AppendJobCompleted 写入 job_completed 终态事件；必须在 UpdateStatus(completed) 前调用（Session1-4 fix）
+	AppendJobCompleted(ctx context.Context, jobID string, goal string) error
+	// AppendJobFailed 写入 job_failed 终态事件；必须在 UpdateStatus(failed) 前调用（Session1-4 fix）
+	AppendJobFailed(ctx context.Context, jobID string, reason string, sf *StepFailure) error
 	// AppendReasoningSnapshot 写入 reasoning_snapshot 事件，供因果调试（design：Causal Debugging）
 	AppendReasoningSnapshot(ctx context.Context, jobID string, payload []byte) error
 	// AppendStepCompensated 写入 step_compensated 事件（2.0 Tool Contract）；补偿回调执行后调用
@@ -290,6 +295,22 @@ func (r *Runner) SetMaxParallelSteps(n int) {
 	r.maxParallelSteps = n
 }
 
+// writeTerminalCompleted Session1-4 fix: 写入 job_completed 事件后再更新 metadata，确保事件流先行
+func (r *Runner) writeTerminalCompleted(ctx context.Context, jobID string, goal string) {
+	if r.nodeEventSink != nil {
+		_ = r.nodeEventSink.AppendJobCompleted(ctx, jobID, goal)
+	}
+	_ = r.jobStore.UpdateStatus(ctx, jobID, 2) // 2 = statusCompleted
+}
+
+// writeTerminalFailed Session1-4 fix: 写入 job_failed 事件后再更新 metadata，确保事件流先行
+func (r *Runner) writeTerminalFailed(ctx context.Context, jobID string, reason string, sf *StepFailure) {
+	if r.nodeEventSink != nil {
+		_ = r.nodeEventSink.AppendJobFailed(ctx, jobID, reason, sf)
+	}
+	_ = r.jobStore.UpdateStatus(ctx, jobID, 3) // 3 = statusFailed
+}
+
 // nextRunnableBatch 返回下一可执行步的索引列表（同层或单步）。completedSet 的 key 为 effectiveStepID。
 // 若 levelGroups 为 nil 则按顺序返回第一个未完成的步。
 func (r *Runner) nextRunnableBatch(steps []SteppableStep, levelGroups [][]string, completedSet map[string]struct{}, jobID, decisionID string) []int {
@@ -390,17 +411,20 @@ func (r *Runner) runParallelLevel(
 		} else {
 			stepCtx = runtime.WithClock(stepCtx, func() time.Time { return time.Now() })
 		}
+		// Fix F: use a per-goroutine cancel captured in the closure so the context is
+		// cancelled as soon as the goroutine finishes, rather than deferring to
+		// runParallelLevel's return (which would accumulate N cancels in memory).
+		var stepCancel context.CancelFunc = func() {} // no-op default
 		if r.stepTimeout > 0 {
-			var cancel context.CancelFunc
-			stepCtx, cancel = context.WithTimeout(stepCtx, r.stepTimeout)
-			defer cancel()
+			stepCtx, stepCancel = context.WithTimeout(stepCtx, r.stepTimeout)
 		}
 		payloadCopy := &AgentDAGPayload{Goal: payload.Goal, AgentID: payload.AgentID, SessionID: payload.SessionID, Results: make(map[string]any)}
 		for k, v := range payload.Results {
 			payloadCopy.Results[k] = v
 		}
-		s, sCtx, eid := step, stepCtx, effectiveStepID
+		s, sCtx, eid, sc := step, stepCtx, effectiveStepID, stepCancel
 		go func() {
+			defer sc() // Fix F: cancel context promptly when step finishes
 			defer func() {
 				if r := recover(); r != nil {
 					ch <- result{idx: idx, payload: payloadCopy, err: fmt.Errorf("panic in step execution: %v", r)}
@@ -449,7 +473,30 @@ func (r *Runner) runParallelLevel(
 		if resultType == StepResultRetryableFailure {
 			metrics.StepRetriesTotal.WithLabelValues(tenant, nodeType, reason).Inc()
 		}
+		// Fix C: write node_finished for sibling steps that succeeded before the failure,
+		// so crash+retry does not re-execute their side effects.
 		if r.nodeEventSink != nil {
+			for _, res := range results {
+				if res.err != nil {
+					continue // skip the failed step (written below) and any other failed steps
+				}
+				siblingStep := steps[res.idx]
+				siblingStepID := DeterministicStepID(j.ID, runLoopDecisionID, res.idx, siblingStep.NodeType)
+				rt := StepResultPure
+				if siblingStep.NodeType == "tool" {
+					rt = StepResultSideEffectCommitted
+				}
+				siblingPayload, marshalErr := marshalJSONForRunner(res.payload.Results, "parallel_sibling_payload")
+				if marshalErr != nil {
+					siblingPayload = []byte("{}")
+				}
+				_ = r.nodeEventSink.AppendNodeFinished(ctx, j.ID, siblingStep.NodeID, siblingPayload, 0, "ok", 1, rt, "", siblingStepID, "")
+				_ = r.nodeEventSink.AppendStepCommitted(ctx, j.ID, siblingStep.NodeID, siblingStepID, siblingStepID, "")
+				if completedSet != nil {
+					completedSet[siblingStepID] = struct{}{}
+				}
+			}
+			// write node_finished for the failed step
 			_ = r.nodeEventSink.AppendNodeFinished(ctx, j.ID, step.NodeID, []byte("{}"), 0, string(resultType), 1, resultType, reason, effectiveStepID, "")
 		}
 		_ = r.jobStore.UpdateStatus(ctx, j.ID, 3)
@@ -507,9 +554,16 @@ func (r *Runner) runParallelLevel(
 		_ = r.jobStore.UpdateStatus(ctx, j.ID, 3)
 		return err
 	}
-	lastIdx := results[len(results)-1].idx
-	lastNodeID := steps[lastIdx].NodeID
-	cp := runtime.NewNodeCheckpoint(agent.ID, sessionID, j.ID, lastNodeID, graphBytes, payloadResults, nil)
+	// Fix B: use the node with the highest index in the batch as CursorNode to ensure
+	// deterministic checkpoint recovery (goroutine completion order is non-deterministic).
+	maxIdx := batch[0]
+	for _, idx := range batch[1:] {
+		if idx > maxIdx {
+			maxIdx = idx
+		}
+	}
+	cursorNodeID := steps[maxIdx].NodeID
+	cp := runtime.NewNodeCheckpoint(agent.ID, sessionID, j.ID, cursorNodeID, graphBytes, payloadResults, nil)
 	cpID, saveErr := r.checkpointStore.Save(ctx, cp)
 	if saveErr != nil {
 		slog.Error("executor: save checkpoint failed", "jobID", j.ID, "error", saveErr)
@@ -624,8 +678,13 @@ func (r *Runner) Advance(ctx context.Context, jobID string, state *replay.Execut
 	payload := NewAgentDAGPayload(j.Goal, agent.ID, sessionID)
 	if len(state.PayloadResults) > 0 {
 		if err := json.Unmarshal(state.PayloadResults, &payload.Results); err != nil {
-			// Log error but continue with empty results to allow replay to proceed
-			// In production, this should be logged via proper logging
+			// Fix G: corrupted payload means we cannot safely replay the job state.
+			// Fail-fast rather than silently continuing with empty results, which would
+			// cause the executor to re-run already-committed side effects.
+			slog.Error("executor: Advance failed to unmarshal payload results",
+				"jobID", jobID, "error", err)
+			_ = r.jobStore.UpdateStatus(ctx, jobID, 3) // statusFailed
+			return false, fmt.Errorf("executor: corrupted payload results for job %s: %w", jobID, err)
 		}
 	}
 	completedSet := state.CompletedNodeIDs
@@ -649,7 +708,12 @@ func (r *Runner) Advance(ctx context.Context, jobID string, state *replay.Execut
 	const statusFailed = 3
 	const statusWaiting = 5
 	if startIndex < 0 || startIndex >= len(steps) {
-		_ = r.jobStore.UpdateStatus(ctx, jobID, statusCompleted)
+		// Session1-4 fix: 写终态事件后再更新 metadata
+		var goal string
+		if j != nil {
+			goal = j.Goal
+		}
+		r.writeTerminalCompleted(ctx, jobID, goal)
 		return true, nil
 	}
 	step := steps[startIndex]
@@ -876,7 +940,6 @@ func (r *Runner) Advance(ctx context.Context, jobID string, state *replay.Execut
 			stateStr = string(resultType)
 		}
 		_ = r.nodeEventSink.AppendNodeFinished(ctx, jobID, step.NodeID, payloadResults, durationMs, stateStr, 1, resultType, reason, effectiveStepID, "")
-		_ = r.nodeEventSink.AppendStepCommitted(ctx, jobID, step.NodeID, effectiveStepID, effectiveStepID, "")
 	}
 	if isStepFailure(resultType) {
 		if resultType == StepResultCompensatableFailure && r.compensationRegistry != nil {
@@ -887,9 +950,16 @@ func (r *Runner) Advance(ctx context.Context, jobID string, state *replay.Execut
 				}
 			}
 		}
-		_ = r.jobStore.UpdateStatus(ctx, jobID, statusFailed)
+		// Session1-4 fix: 写终态事件后再更新 metadata
 		sf := &StepFailure{Type: resultType, Inner: runErr, NodeID: step.NodeID}
+		r.writeTerminalFailed(ctx, jobID, sf.Error(), sf)
 		return false, fmt.Errorf("executor: 节点 %s execution failed (%s): %w", step.NodeID, resultType, sf)
+	}
+	// Fix D: AppendStepCommitted only after confirming the step succeeded (Exactly-Once barrier
+	// must not be written for failed steps — it would corrupt audit data and could mislead
+	// any future code that uses step_committed for replay decisions).
+	if r.nodeEventSink != nil {
+		_ = r.nodeEventSink.AppendStepCommitted(ctx, jobID, step.NodeID, effectiveStepID, effectiveStepID, "")
 	}
 	if r.nodeEventSink != nil {
 		opts := &StateCheckpointOpts{ChangedKeys: ChangedKeysFromState(stateBefore, payloadResults)}
@@ -946,8 +1016,9 @@ func (r *Runner) RunForJob(ctx context.Context, agent *runtime.Agent, j *JobForR
 	// replayCtx：仅从事件流 Replay 进入时非空，含 CompletedCommandIDs/CommandResults，用于命令级跳过与注入
 	var replayCtx *replay.ReplayContext
 
-	// 与 job.JobStatus 对应，避免 executor 依赖 job 包：2=Completed, 3=Failed
+	// 与 job.JobStatus 对应，避免 executor 依赖 job 包：2=Completed, 3=Failed, 5=Waiting
 	const statusFailed = 3
+	const statusWaiting = 5
 	if j.Cursor != "" {
 		cp, loadErr := r.checkpointStore.Load(ctx, j.Cursor)
 		if loadErr != nil || cp == nil {
@@ -989,6 +1060,13 @@ func (r *Runner) RunForJob(ctx context.Context, agent *runtime.Agent, j *JobForR
 		}
 		// 有 replayBuilder 时从 checkpoint 构建 state，走事件驱动循环
 		if r.replayBuilder != nil {
+			// Session1-1 fix: checkpoint 保存失败时，node_finished 事件已写入但 checkpoint 未更新，
+			// 导致 completedSet 缺少该节点 → 合并事件流中的已完成节点，防止 Advance 重复执行。
+			if freshRCtx, _ := r.replayBuilder.BuildFromSnapshot(ctx, j.ID); freshRCtx != nil {
+				for k := range freshRCtx.CompletedNodeIDs {
+					completedSet[k] = struct{}{}
+				}
+			}
 			rc := &replay.ReplayContext{
 				TaskGraphState:           cp.TaskGraphState,
 				CursorNode:               cp.CursorNode,
@@ -1031,6 +1109,12 @@ func (r *Runner) RunForJob(ctx context.Context, agent *runtime.Agent, j *JobForR
 							runtime.ApplyAgentState(agent.Session, &as)
 						}
 					}
+					// Session1-2 fix: 若事件流末尾已是 job_waiting（尚无 wait_completed），
+					// 说明本次调度是重复投递，直接返回 ErrJobWaiting 避免重写 job_waiting 事件。
+					if rctx.Phase == replay.PhaseWaiting {
+						_ = r.jobStore.UpdateStatus(ctx, j.ID, statusWaiting)
+						return ErrJobWaiting
+					}
 					// 仅当事件流已有执行进度（command/node/tool）时才进入 Replay 驱动循环；
 					// 仅有 plan_generated 时应走 fresh execution，允许首次真实执行副作用节点（如 LLM）。
 					if hasReplayProgress(rctx) {
@@ -1047,6 +1131,11 @@ func (r *Runner) RunForJob(ctx context.Context, agent *runtime.Agent, j *JobForR
 							rctx, _ = r.replayBuilder.BuildFromSnapshot(ctx, j.ID)
 							if rctx == nil {
 								break
+							}
+							// Session1-2 fix: Advance 完成一步后若已进入等待状态，退出循环
+							if rctx.Phase == replay.PhaseWaiting {
+								_ = r.jobStore.UpdateStatus(ctx, j.ID, statusWaiting)
+								return ErrJobWaiting
 							}
 							if len(rctx.WorkingMemorySnapshot) > 0 && agent != nil && agent.Session != nil {
 								var as runtime.AgentState
@@ -1095,14 +1184,14 @@ runLoop:
 	}
 	ctx = WithTenantID(ctx, tenantCtx)
 	const statusCompleted = 2 // 对应 job.StatusCompleted
-	const statusWaiting = 5   // 对应 job.StatusWaiting（design/job-state-machine.md）
 	graphBytes, _ := taskGraph.Marshal()
 	runLoopDecisionID := PlanDecisionID(graphBytes)
 	levelGroups, _ := LevelGroups(taskGraph)
 	for {
 		batch := r.nextRunnableBatch(steps, levelGroups, completedSet, j.ID, runLoopDecisionID)
 		if len(batch) == 0 {
-			_ = r.jobStore.UpdateStatus(ctx, j.ID, statusCompleted)
+			// Session1-4 fix: 写终态事件后再更新 metadata
+			r.writeTerminalCompleted(ctx, j.ID, j.Goal)
 			return nil
 		}
 		hasWait := false
@@ -1346,10 +1435,11 @@ runLoop:
 		} else {
 			runCtx = runtime.WithClock(runCtx, func() time.Time { return time.Now() })
 		}
+		// Fix F: use an explicit cancel variable rather than defer, so the timeout context
+		// is released at the end of each iteration (not when RunForJob returns).
+		var stepCancel context.CancelFunc
 		if r.stepTimeout > 0 {
-			var cancel context.CancelFunc
-			runCtx, cancel = context.WithTimeout(runCtx, r.stepTimeout)
-			defer cancel()
+			runCtx, stepCancel = context.WithTimeout(runCtx, r.stepTimeout)
 		}
 		// 2.0 Deterministic Replay：标记 Replay 模式
 		runCtx = determinism.WithReplay(runCtx, replayCtx != nil)
@@ -1358,7 +1448,7 @@ runLoop:
 			runCtx = agenteffects.WithRecordedEffects(runCtx, j.ID, effectiveStepID, replayCtx, r.recordedEffectsRecorder)
 		}
 		runCtx = sdk.WithRuntimeContext(runCtx, newRuntimeContextAdapter(j.ID, effectiveStepID))
-		// Node span for tracing
+		// Node span for tracing; defer is acceptable here since spans close when RunForJob returns.
 		ctx, nodeSpan := tracing.StartNodeSpan(ctx, step.NodeID, step.NodeType)
 		defer nodeSpan.End()
 		var runErr error
@@ -1381,11 +1471,17 @@ runLoop:
 				resumptionBytes, err := marshalJSONForRunner(resumptionCtx, "runloop_signal_wait_resumption")
 				if err != nil {
 					_ = r.jobStore.UpdateStatus(ctx, j.ID, statusFailed)
+					if stepCancel != nil {
+						stepCancel()
+					}
 					return err
 				}
 				_ = r.nodeEventSink.AppendJobWaiting(ctx, j.ID, step.NodeID, "signal", waitReason, time.Now().Add(24*time.Hour), correlationKey, resumptionBytes)
 			}
 			_ = r.jobStore.UpdateStatus(ctx, j.ID, statusWaiting)
+			if stepCancel != nil {
+				stepCancel()
+			}
 			return ErrJobWaiting
 		}
 		resultType, reason := ClassifyError(runErr)
@@ -1431,6 +1527,9 @@ runLoop:
 		payloadResults, err := marshalJSONForRunner(payload.Results, "runloop_payload_results")
 		if err != nil {
 			_ = r.jobStore.UpdateStatus(ctx, j.ID, statusFailed)
+			if stepCancel != nil {
+				stepCancel()
+			}
 			return err
 		}
 		if runErr != nil && len(payloadResults) == 0 {
@@ -1442,7 +1541,6 @@ runLoop:
 				stateStr = string(resultType)
 			}
 			_ = r.nodeEventSink.AppendNodeFinished(ctx, j.ID, step.NodeID, payloadResults, durationMs, stateStr, 1, resultType, reason, effectiveStepID, "")
-			_ = r.nodeEventSink.AppendStepCommitted(ctx, j.ID, step.NodeID, effectiveStepID, effectiveStepID, "")
 		}
 		// Record node execution metrics
 		status := "success"
@@ -1459,9 +1557,18 @@ runLoop:
 					}
 				}
 			}
-			_ = r.jobStore.UpdateStatus(ctx, j.ID, statusFailed)
+			// Session1-4 fix: 写终态事件后再更新 metadata
 			sf := &StepFailure{Type: resultType, Inner: runErr, NodeID: step.NodeID}
+			r.writeTerminalFailed(ctx, j.ID, sf.Error(), sf)
+			if stepCancel != nil {
+				stepCancel()
+			}
 			return fmt.Errorf("executor: 节点 %s execution failed (%s): %w", step.NodeID, resultType, sf)
+		}
+		// Fix D: AppendStepCommitted only after confirming the step succeeded (Exactly-Once
+		// barrier must not be written for failed steps).
+		if r.nodeEventSink != nil {
+			_ = r.nodeEventSink.AppendStepCommitted(ctx, j.ID, step.NodeID, effectiveStepID, effectiveStepID, "")
 		}
 		if r.nodeEventSink != nil {
 			opts := &StateCheckpointOpts{ChangedKeys: ChangedKeysFromState(stateBefore, payloadResults)}
@@ -1515,6 +1622,9 @@ runLoop:
 		if saveErr != nil {
 			slog.Error("executor: save checkpoint failed", "jobID", j.ID, "error", saveErr)
 			_ = r.jobStore.UpdateStatus(ctx, j.ID, statusFailed)
+			if stepCancel != nil {
+				stepCancel()
+			}
 			return fmt.Errorf("executor: save checkpoint failed: %w", saveErr)
 		}
 		if agent.Session != nil {
@@ -1526,6 +1636,11 @@ runLoop:
 		}
 		completedSet[effectiveStepID] = struct{}{}
 		completedSet[step.NodeID] = struct{}{}
+		// Fix F: explicitly cancel the step-scoped timeout context at end of each successful
+		// iteration so timer goroutines are released promptly instead of at RunForJob return.
+		if stepCancel != nil {
+			stepCancel()
+		}
 		continue
 	}
 }

--- a/internal/agent/runtime/executor/runner.go
+++ b/internal/agent/runtime/executor/runner.go
@@ -704,7 +704,6 @@ func (r *Runner) Advance(ctx context.Context, jobID string, state *replay.Execut
 		startIndex = i
 		break
 	}
-	const statusCompleted = 2
 	const statusFailed = 3
 	const statusWaiting = 5
 	if startIndex < 0 || startIndex >= len(steps) {
@@ -1183,7 +1182,6 @@ runLoop:
 		tenantCtx = j.TenantID
 	}
 	ctx = WithTenantID(ctx, tenantCtx)
-	const statusCompleted = 2 // 对应 job.StatusCompleted
 	graphBytes, _ := taskGraph.Marshal()
 	runLoopDecisionID := PlanDecisionID(graphBytes)
 	levelGroups, _ := LevelGroups(taskGraph)

--- a/internal/agent/runtime/executor/runner_timeout_test.go
+++ b/internal/agent/runtime/executor/runner_timeout_test.go
@@ -78,6 +78,14 @@ func (s *timeoutNodeSink) AppendPlanEvolution(ctx context.Context, jobID string,
 	return nil
 }
 
+func (s *timeoutNodeSink) AppendJobCompleted(ctx context.Context, jobID string, goal string) error {
+	return nil
+}
+
+func (s *timeoutNodeSink) AppendJobFailed(ctx context.Context, jobID string, reason string, sf *StepFailure) error {
+	return nil
+}
+
 func (s *timeoutNodeSink) snapshot() (string, StepResultType, string, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/agent/runtime/scheduler_distributed.go
+++ b/internal/agent/runtime/scheduler_distributed.go
@@ -102,21 +102,61 @@ func (s *SchedulerDistributed) WakeAgent(ctx context.Context, agentID string) er
 		// 未能获取锁，说明其他 Worker 正在处理
 		return nil
 	}
-	defer s.releaseLock(ctx, agentID, lockValue)
 
 	agent, err := s.manager.Get(ctx, agentID)
 	if err != nil || agent == nil {
+		_ = s.releaseLock(ctx, agentID, lockValue)
 		return nil
 	}
 	status := agent.GetStatus()
 	if status == StatusRunning || status == StatusWaitingTool {
+		_ = s.releaseLock(ctx, agentID, lockValue)
 		return nil
 	}
 	agent.SetStatus(StatusRunning)
+
+	// Fix E: start a background goroutine to renew the lock TTL while the agent runs.
+	// Without this, any agent execution longer than lockTTL would have its lock expire,
+	// allowing another worker to acquire it and run the same agent concurrently.
+	renewCtx, stopRenew := context.WithCancel(context.Background())
+	go s.keepLockAlive(renewCtx, agentID, lockValue)
+
 	if s.run != nil {
 		s.run(ctx, agentID)
 	}
+
+	// Stop renewal before releasing so we don't race with releaseLock.
+	stopRenew()
+	_ = s.releaseLock(ctx, agentID, lockValue)
 	return nil
+}
+
+// keepLockAlive 每隔 lockTTL/2 续期一次分布式锁，防止执行时间超过 TTL 导致锁过期。
+// 通过 Lua 脚本做 compare-and-expire，确保只续期自己持有的锁。
+func (s *SchedulerDistributed) keepLockAlive(ctx context.Context, agentID, lockValue string) {
+	renewInterval := s.lockTTL / 2
+	if renewInterval < time.Second {
+		renewInterval = time.Second
+	}
+	ticker := time.NewTicker(renewInterval)
+	defer ticker.Stop()
+	lockKey := s.keyPrefix + "lock:" + agentID
+	script := redis.NewScript(`
+		if redis.call("get", KEYS[1]) == ARGV[1] then
+			return redis.call("pexpire", KEYS[1], ARGV[2])
+		else
+			return 0
+		end
+	`)
+	ttlMs := s.lockTTL.Milliseconds()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			_ = script.Run(ctx, s.redis, []string{lockKey}, lockValue, ttlMs).Err()
+		}
+	}
 }
 
 // Suspend 挂起 Agent
@@ -138,17 +178,25 @@ func (s *SchedulerDistributed) Resume(ctx context.Context, agentID string) error
 	if !acquired {
 		return nil
 	}
-	defer s.releaseLock(ctx, agentID, lockValue)
 
 	agent, err := s.manager.Get(ctx, agentID)
 	if err != nil || agent == nil {
+		_ = s.releaseLock(ctx, agentID, lockValue)
 		return nil
 	}
 	agent.SetStatus(StatusIdle)
 	agent.SetStatus(StatusRunning)
+
+	// Fix E: same lock-renewal pattern as WakeAgent.
+	renewCtx, stopRenew := context.WithCancel(context.Background())
+	go s.keepLockAlive(renewCtx, agentID, lockValue)
+
 	if s.run != nil {
 		s.run(ctx, agentID)
 	}
+
+	stopRenew()
+	_ = s.releaseLock(ctx, agentID, lockValue)
 	return nil
 }
 

--- a/internal/app/api/app.go
+++ b/internal/app/api/app.go
@@ -616,22 +616,32 @@ func NewApp(bootstrap *app.Bootstrap) (*App, error) {
 			_ = agentStateStore.SaveAgentState(ctx, j.AgentID, agent.Session.ID, runtime.SessionToAgentState(agent.Session))
 		}
 		// 事件流补全：执行结束后追加 JobCompleted / JobFailed，便于审计与回放
+		// Session1-4 fix: 若 runner 已写入终态事件，跳过重复写入
 		if jobEventStore != nil {
-			_, ver, _ := jobEventStore.ListEvents(ctx, j.ID)
-			evType := jobstore.JobCompleted
-			pl := map[string]interface{}{"goal": j.Goal}
-			if err != nil {
-				evType = jobstore.JobFailed
-				pl["error"] = err.Error()
-				var sf *agentexec.StepFailure
-				if errors.As(err, &sf) {
-					pl["result_type"] = string(sf.Type)
-					pl["node_id"] = sf.FailedNodeID()
-					pl["reason"] = err.Error()
+			existingEvents, ver, _ := jobEventStore.ListEvents(ctx, j.ID)
+			alreadyTerminal := false
+			for _, ev := range existingEvents {
+				if ev.Type == jobstore.JobCompleted || ev.Type == jobstore.JobFailed || ev.Type == jobstore.JobCancelled {
+					alreadyTerminal = true
+					break
 				}
 			}
-			payload, _ := json.Marshal(pl)
-			_, _ = jobEventStore.Append(ctx, j.ID, ver, jobstore.JobEvent{JobID: j.ID, Type: evType, Payload: payload})
+			if !alreadyTerminal {
+				evType := jobstore.JobCompleted
+				pl := map[string]interface{}{"goal": j.Goal}
+				if err != nil {
+					evType = jobstore.JobFailed
+					pl["error"] = err.Error()
+					var sf *agentexec.StepFailure
+					if errors.As(err, &sf) {
+						pl["result_type"] = string(sf.Type)
+						pl["node_id"] = sf.FailedNodeID()
+						pl["reason"] = err.Error()
+					}
+				}
+				payload, _ := json.Marshal(pl)
+				_, _ = jobEventStore.Append(ctx, j.ID, ver, jobstore.JobEvent{JobID: j.ID, Type: evType, Payload: payload})
+			}
 		}
 		return err
 	}

--- a/internal/app/api/node_sink.go
+++ b/internal/app/api/node_sink.go
@@ -602,6 +602,47 @@ func (s *nodeEventSinkImpl) AppendPlanEvolution(ctx context.Context, jobID strin
 	return err
 }
 
+// AppendJobCompleted 实现 NodeEventSink；写入 job_completed 终态事件（Session1-4 fix）
+// 必须在 UpdateStatus(completed) 前调用，确保事件流写入先于 metadata 更新。
+func (s *nodeEventSinkImpl) AppendJobCompleted(ctx context.Context, jobID string, goal string) error {
+	if s.store == nil {
+		return nil
+	}
+	_, ver, err := s.store.ListEvents(ctx, jobID)
+	if err != nil {
+		return err
+	}
+	pl := map[string]interface{}{"goal": goal}
+	payload, _ := json.Marshal(pl)
+	_, err = s.store.Append(ctx, jobID, ver, jobstore.JobEvent{
+		JobID: jobID, Type: jobstore.JobCompleted, Payload: payload,
+	})
+	return err
+}
+
+// AppendJobFailed 实现 NodeEventSink；写入 job_failed 终态事件（Session1-4 fix）
+// 必须在 UpdateStatus(failed) 前调用，确保事件流写入先于 metadata 更新。
+func (s *nodeEventSinkImpl) AppendJobFailed(ctx context.Context, jobID string, reason string, sf *agentexec.StepFailure) error {
+	if s.store == nil {
+		return nil
+	}
+	_, ver, err := s.store.ListEvents(ctx, jobID)
+	if err != nil {
+		return err
+	}
+	pl := map[string]interface{}{"error": reason}
+	if sf != nil {
+		pl["result_type"] = string(sf.Type)
+		pl["node_id"] = sf.FailedNodeID()
+		pl["reason"] = reason
+	}
+	payload, _ := json.Marshal(pl)
+	_, err = s.store.Append(ctx, jobID, ver, jobstore.JobEvent{
+		JobID: jobID, Type: jobstore.JobFailed, Payload: payload,
+	})
+	return err
+}
+
 // NewReplayContextBuilder 创建从事件流重建 ReplayContext 的 Builder（供 Runner 无 Checkpoint 时恢复）
 func NewReplayContextBuilder(store jobstore.JobStore) replay.ReplayContextBuilder {
 	return replay.NewReplayContextBuilder(store)

--- a/internal/runtime/jobstore/snapshot.go
+++ b/internal/runtime/jobstore/snapshot.go
@@ -42,11 +42,13 @@ type SnapshotPayload struct {
 	StateChangesByStep       map[string]json.RawMessage `json:"state_changes_by_step,omitempty"`
 	ApprovedCorrelationKeys  []string                   `json:"approved_correlation_keys,omitempty"`
 	WorkingMemorySnapshot    json.RawMessage            `json:"working_memory_snapshot,omitempty"`
-	Phase                    int                        `json:"phase,omitempty"`
-	RecordedTime             map[string]int64           `json:"recorded_time,omitempty"`
-	RecordedRandom           map[string]json.RawMessage `json:"recorded_random,omitempty"`
-	RecordedUUID             map[string]string          `json:"recorded_uuid,omitempty"`
-	RecordedHTTP             map[string]json.RawMessage `json:"recorded_http,omitempty"`
+	// PendingWaitNode Session1-2: 尚未收到 wait_completed 的 job_waiting 节点 ID
+	PendingWaitNode string                     `json:"pending_wait_node,omitempty"`
+	Phase           int                        `json:"phase,omitempty"`
+	RecordedTime    map[string]int64           `json:"recorded_time,omitempty"`
+	RecordedRandom  map[string]json.RawMessage `json:"recorded_random,omitempty"`
+	RecordedUUID    map[string]string          `json:"recorded_uuid,omitempty"`
+	RecordedHTTP    map[string]json.RawMessage `json:"recorded_http,omitempty"`
 }
 
 // SnapshotStore 快照存储接口，扩展 JobStore


### PR DESCRIPTION
## 背景

修复 Session 1 发现的四类运行时可靠性缺陷，涉及 replay 状态重建、Waiting 短路、孤儿 job 回收以及终态事件写入顺序。

## 变更列表

### Fix 1 — cursor 路径 completedSet 缺失 post-checkpoint 事件
- `runner.go`: cursor 路径恢复后，从事件流补充 `completedSet`，避免 Advance 重复执行已提交节点。

### Fix 2 — `job_waiting` 未在 ReplayContext 持久化 (Session1-2)
- `replay.go`: 新增 `PhaseWaiting = 6` 常量和 `PendingWaitNode string` 字段；`BuildFromEvents`/`applyIncrementalEvents` 正确处理 `job_waiting`/`wait_completed` 事件。
- `snapshot.go`: `SnapshotPayload` 新增 `PendingWaitNode` 字段，`SerializeReplayContext`/`deserializeSnapshot` 同步序列化。
- `runner.go`: replay 路径和 Advance 循环中加入 `PhaseWaiting` 短路，避免重复写入 `job_waiting` 事件。

### Fix 3 — 孤儿 job 回收忽略终态/等待事件 (Session1-3)
- `reclaim.go`: `ReclaimOrphanedFromEventStore` 改用 `DeriveStatusFromEvents` 推导状态；终态 job 同步 metadata、Waiting/Parked 跳过、其余过期 lease 才回收为 Pending。

### Fix 4 — 终态事件写入晚于 metadata 更新 (Session1-4)
- `runner.go`: 新增 `NodeEventSink.AppendJobCompleted`/`AppendJobFailed` 接口方法；新增 `writeTerminalCompleted`/`writeTerminalFailed` helper，先写事件流再更新 metadata。
- `node_sink.go`: 实现两个新接口方法，写入 `job_completed`/`job_failed` 事件。
- `app.go`: worker 循环写终态事件前先检查事件流，避免与 runner 重复写入。
- `runner_timeout_test.go`: mock `timeoutNodeSink` 补充新接口方法 stub。

## 测试

```
go build -tags distributed ./...  # OK
go vet -tags distributed ./...    # OK
go test -race -count=1 ./internal/agent/runtime/... ./internal/agent/runtime/executor/... ./internal/agent/job/...
# ok internal/.../runtime, executor, eino_examples, job
```