### PR TITLE
docs: 重写 README，用场景化叙事替代 feature list

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,72 +12,99 @@
 
 <div align="center">
 
-## ⭐ The Missing Layer for Production-Ready AI Agents
+## ⭐ Durable Execution for AI Agents — Build Anywhere, Run Reliably in Production
 
-**Aetheris** is a durable, replayable execution runtime — the "Temporal for Agents" that your production AI systems desperately need.
+**Aetheris** is the execution runtime that makes your AI agents survive crashes, avoid duplicate calls, and let you replay any failure like a video recording.
 
-[Quick Start](#installation) • [Documentation](docs/guides/get-started.md) • [Examples](examples/) • [Blog](docs/blog/) • [Discord](https://discord.gg/PrrK2Mua)
+[Quick Start](#-quick-start) • [Documentation](docs/guides/get-started.md) • [Examples](examples/) • [Discord](https://discord.gg/PrrK2Mua)
 
 </div>
 
 ---
 
-## 🤔 Why Aetheris?
+## 😰 你是否遇到过这些崩溃噩梦？
 
-Your AI agent worked in testing. But production is different.
+**场景一：半夜报警，API 被重复调用了 3 次**
+> 用户提交订单，Agent 调用支付 API，Worker 刚好在这时崩溃。
+> 重启后 Agent 不知道支付到底成功没有——**再调一次**。
+> 恭喜，用户被扣了三次钱。
+
+**场景二：跑了 2 小时的报告，最后一步崩了**
+> Agent 要处理 10,000 条数据，跑到第 9,800 条时 OOM。
+> 重启后从零开始，用户第二天早上才拿到报告，投诉工单已堆积。
+
+**场景三：Agent 执行到一半，需要人工审批**
+> Agent 准备给用户退款 $50,000——你想先审批。
+> 审批完了让 Agent 继续，但它的上下文已经丢了，状态全乱了。
+
+**场景四：生产出了 bug，不知道 Agent 做了什么**
+> Agent 给用户推荐了错误的理财产品。
+> 你想回放它的思考过程，但根本没有记录，只能靠猜。
+
+---
+
+## 😮‍💨 Aetheris 之前的无奈
 
 ```
-❌ Worker crashed → Restart from beginning
-❌ Tool called twice → Duplicate payments
-❌ Need to audit AI decisions → No trace
-❌ Agent waiting for approval → Wastes resources
-❌ Need to replay failed run → Impossible
+你的 AI Agent：
+❌ Worker 重启 → 从头开始跑，用户等 10 分钟
+❌ 支付完成后崩溃 → 不知道付没付，钱打水漂或重复扣
+❌ 出 bug 想回放 → 不可能，只能重跑
+❌ 要人工审批 → 只能重新问用户，上下文丢失
+❌ 监管审计 → 拿不出证据，解释不清
 ```
 
-Go agent frameworks (LangChainGo, LangGraphGo, ADK) build agents. **Aetheris runs them in production.**
+---
+
+## 🚀 Aetheris 之后的体验
+
+```
+用 Aetheris 跑你的 Agent：
+✅ Worker 重启 → 从上一次成功的步骤继续，毫秒级恢复
+✅ 支付完成后崩溃 → 事件溯源，能查到"第几步完成的"
+✅ 出 bug 想回放 → 任意时间点重放，像看录像一样定位问题
+✅ 要人工审批 → 状态 park，等你 approve，从断点继续
+✅ 监管审计 → 完整决策链，step by step 的证据包
+```
+
+> **不改变你写 Agent 的方式**，只用 Aetheris 托管你的 Agent，它帮你兜底可靠性。
 
 ---
 
-## 🎯 What is Aetheris?
+## 🎯 什么感觉？像给 Agent 装了一个"黑匣子 + 时光机"
 
-> **Kubernetes for AI Agents**
-
-Aetheris manages agents — providing durability, reliability, and observability for production systems.
-
-**It's not:**
-- ❌ Chatbot framework
-- ❌ Prompt library
-- ❌ RAG system
-- ❌ Another way to write agents
-
-**It is:**
-- ✅ Agent execution runtime — host LangChainGo/LangGraphGo/ADK agents
-- ✅ Durable execution — survive crashes, resume from checkpoints
-- ✅ Reliable orchestrator — at-most-once tool execution
-- ✅ Auditable system — full decision history
+| 你现在的 Agent | 加上 Aetheris |
+| -------------- | -------------- |
+| 崩溃 = 丢失所有进度 | 崩溃 = 从上一次 checkpoint 继续 |
+| 工具调用没有幂等保证 | 同一工具调用，永远只执行一次 |
+| 失败后只能重头跑 | 任意步骤可重放，精准定位 bug |
+| 审批 = 状态丢失 | 审批 = 状态 Park，approve 后无缝衔接 |
+| 生产问题靠猜 | 完整执行链路，随时回放审计 |
 
 ---
 
-## ✨ Key Features
+## ✨ 核心能力
 
-| Feature | What It Means |
-| ------- | --------------- |
-| **At-Most-Once** | Tool calls never repeat, even after crashes |
-| **Crash Recovery** | Resume from checkpoints, not from scratch |
-| **Deterministic Replay** | Reproduce any run for debugging |
-| **Human-in-the-Loop** | Pause for approval, resume without waste |
-| **Full Audit Trail** | Every decision traced |
-| **Multi-Framework** | Plug in LangChainGo/LangGraphGo/ADK |
+| 能力 | 听起来像 | 实际上解决了 |
+| ---- | -------- | ------------ |
+| **At-Most-Once** | "工具调用不重复" | 你的支付 API 再也不会被调用两次 |
+| **Crash Recovery** | "崩溃能恢复" | 跑了 2 小时的报告不会被清零 |
+| **Deterministic Replay** | "可以回放" | 出 bug 能像看录像一样定位 |
+| **Human-in-the-Loop** | "人工审批" | 大额操作等你批准再继续 |
+| **Event Sourcing** | "事件溯源" | 监管来查，你有一整条证据链 |
 
 ---
 
-## 📊 Use Cases
+## 📊 什么时候用？真实场景举例
 
-| Use Case | Description |
-| -------- | ------------- |
-| **Human-in-the-Loop** | Agents pause for approval, resume with full context |
-| **Compliance & Audit** | Event-sourced traceability, replayable evidence |
-| **Local-First** | Private cloud, air-gapped environments |
+| 场景 | 不用 Aetheris | 用了 Aetheris |
+| ---- | -------------- | -------------- |
+| **支付场景** | 支付完成后 Worker 崩溃，重复扣款 | 事件溯源，幂等保证，崩溃也能确认支付状态 |
+| **长任务处理** | 处理 1 万条数据，崩在最后 1 条，全部重跑 | Checkpoint 恢复，从断点继续，API 只调一次 |
+| **需要审批** | Agent 执行到一半要等审批，状态丢失 | StatusParked，审批通过后无缝从断点继续 |
+| **合规审计** | 监管来查，拿不出 Agent 决策证据 | 完整事件链，step by step 回放 |
+| **Bug 调试** | 生产出 bug，只能重跑一遍看日志猜 | 任意时间点重放执行，像看录像一样定位 |
+| **多 Agent 协作** | 一个 Agent 挂了，其他不知道状态 | 各 Agent 独立持久化，独立恢复 |
 
 ---
 
@@ -236,18 +263,18 @@ Aetheris makes agents production-ready.
 
 ---
 
-## 🧩 Templates & Ecosystem
+## 🧩 开箱即用的场景模板
 
-Start fast with production-ready templates:
+不想从零搭？直接跑起来：
 
-| Template | Description |
-|----------|-------------|
-| [Customer Service Agent](./templates/customer-service-agent/) | Multi-turn support with human approval |
-| [RAG Assistant](./templates/rag-assistant/) | Vector search + LLM with citations |
-| [Autonomous Researcher](./templates/autonomous-researcher/) | Self-directed research agent |
-| [Multi-Agent Debate](./templates/multi-agent-debate/) | Multi-agent discussion & consensus |
+| 模板 | 解决什么问题 |
+| ---- | ------------ |
+| [**客服 Agent**](./templates/customer-service-agent/) | 用户问退货 → 调库存 → 审批退款 → 执行退款，全流程不丢状态 |
+| [**RAG 助手**](./templates/rag-assistant/) | 上传 PDF → 自动向量化 → 问答，所有步骤可重放 |
+| [**自动研究员**](./templates/autonomous-researcher/) | 丢一个主题，它自己搜、自己读、自己总结，崩了能从断点继续 |
+| [**多 Agent 辩论**](./templates/multi-agent-debate/) | 多个 Agent 协作讨论，挂了不影响整体，独立恢复 |
 
-[MCP Gateway](./tools/mcp-gateway/) — Pre-built tools: GitHub, Filesystem, Web Search, Database
+[**MCP Gateway**](./tools/mcp-gateway/) — 预置工具：GitHub、文件系统、网页搜索、数据库
 
 [VSCode Extension](./tools/vscode-extension/) — Code snippets & syntax highlighting
 
@@ -278,54 +305,3 @@ Built with [eino](https://github.com/cloudwego/eino), [hertz](https://github.com
 **⭐ Star us. Build production agents. Ship with confidence.**
 
 </div>
-
----
-
-## 📚 Long-tail Keywords & SEO Terms
-
-*This section helps improve searchability for specific use cases and related queries.*
-
-### Core Use Case Keywords
-- durable AI agent execution runtime
-- AI agent crash recovery and checkpoint
-- production AI agent orchestration
-- at-most-once tool execution AI
-- event-sourced AI agent audit trail
-- deterministic AI agent replay
-
-### Technical Keywords
-- Go AI agent framework production
-- LangChainGo production deployment
-- LangGraphGo durability
-- AI agent human-in-the-loop approval
-- AI agent state management
-- AI agent workflow checkpointing
-- AI agent idempotency guarantee
-- AI agent observability and tracing
-
-### Industry Keywords
-- enterprise AI agent compliance
-- AI agent local-first deployment
-- AI agent private cloud
-- AI agent air-gapped environment
-- AI agent regulatory audit
-- AI agent financial services compliance
-- AI agent healthcare data handling
-
-### Feature Keywords
-- AI agent checkpoint resume
-- AI agent decision replay
-- AI agent full stacktrace
-- AI agent failure recovery
-- AI agent retry with fencing
-- AI agent lease management
-- AI agent side effect ledger
-- AI agent effect store
-
-### Integration Keywords
-- Eino framework integration
-- MCP server agent hosting
-- AI agent MCP tool bridge
-- ADK agent hosting runtime
-- AI agent API gateway
-- AI agent webhook integration


### PR DESCRIPTION
- 开头改为 4 个具体崩溃噩梦场景，让用户想到自己的痛
- 用❌之前 vs ✅之后的对比例子替代抽象术语
- 核心能力加了'实际上解决了什么'列，翻译成人话
- 场景举例表改成中文，覆盖支付/长任务/审批/合规/bug调试/多Agent
- 模板描述改成工作流链路（用户问退货→调库存→审批→执行）
- 删掉 SEO 关键词堆砌段落

## Summary

Describe the change and why it is needed.

## Changes

- 

## Validation

- [ ] `go test ./...`
- [ ] `go build ./...`
- [ ] docs updated when behavior changed

## Compatibility / Risk

Call out breaking changes, migrations, or runtime risks.

## Related Issues

Link related issues (e.g. `Closes #123`).

