### PR TITLE
docs: 深化场景叙事与技术文档内容

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,34 +24,64 @@
 
 ## 😰 你是否遇到过这些崩溃噩梦？
 
-**场景一：半夜报警，API 被重复调用了 3 次**
-> 用户提交订单，Agent 调用支付 API，Worker 刚好在这时崩溃。
-> 重启后 Agent 不知道支付到底成功没有——**再调一次**。
-> 恭喜，用户被扣了三次钱。
+**场景一：半夜报警，支付 API 被重复调用了 3 次**
+> 用户提交订单，Agent 完成风控检查、调起支付 API，Worker 刚好在「写完支付记录」但「还没更新订单状态」时崩溃。
+> 重启后 Agent 不知道支付到底成功没有——**再调一次**。再崩——**再调一次**。
+>
+> 技术根因：Agent 没有「幂等键 + 执行台账」，**重试 = 重复扣款**。
+> 实际损失：用户被扣了三次钱，客诉工单 + 对账修复 + 运营介入，一个晚上的事故。
 
-**场景二：跑了 2 小时的报告，最后一步崩了**
-> Agent 要处理 10,000 条数据，跑到第 9,800 条时 OOM。
-> 重启后从零开始，用户第二天早上才拿到报告，投诉工单已堆积。
+**场景二：跑了 4 小时的合规报告，倒数第二步崩了**
+> 合规 Agent 需要抓取 10,000 份合同、调用 LLM 逐份摘要、汇总输出审计报告。
+> 跑到 9,800 份时 Worker OOM。重启后——**从第 1 份重新开始**，LLM token 全部重烧。
+>
+> 技术根因：没有 Checkpoint，**任何一步失败 = 全部重跑**。
+> 实际损失：4 小时变 8 小时，LLM 费用翻倍，合规截止日差点 miss。
 
-**场景三：Agent 执行到一半，需要人工审批**
-> Agent 准备给用户退款 $50,000——你想先审批。
-> 审批完了让 Agent 继续，但它的上下文已经丢了，状态全乱了。
+**场景三：大额退款 Agent 执行到一半，等了 3 天审批，上下文丢了**
+> Agent 准备给用户退款 ¥500,000——风控系统触发人工审批。
+> 你 3 天后批准了，Agent 重新跑——**原来的对话记忆、风控结果、中间状态全没了**。
+> 只能重新查询所有上游数据，有些数据已经变了，结果不一致。
+>
+> 技术根因：没有「状态 Park + 断点续传」，**审批 = 上下文清零**。
+> 实际损失：重复触发风控 API、多次审批流转、数据不一致导致二次核查。
 
-**场景四：生产出了 bug，不知道 Agent 做了什么**
-> Agent 给用户推荐了错误的理财产品。
-> 你想回放它的思考过程，但根本没有记录，只能靠猜。
+**场景四：生产出了 bug，监管要求还原 Agent 决策过程**
+> Agent 给用户推荐了不适合的理财产品，用户亏损投诉，监管介入。
+> 你想还原 Agent 当时的完整推理过程，但根本没有记录——LLM 调用了什么、Tool 返回了什么、中间做了什么判断，全靠猜。
+>
+> 技术根因：没有「事件溯源 + 确定性回放」，**出问题 = 无法解释**。
+> 实际损失：监管罚款、合规人员加班、无法证明 AI 决策链路合规。
+
+**场景五：供应链 Agent 调了 30 个供应商 API，不知道哪些已经确认了**
+> 采购 Agent 同时向 30 个供应商发送询价并确认库存，中途网络分区，部分请求超时。
+> 重启后 Agent 无法判断哪些供应商已经收到了确认——**重发所有请求**，导致双重采购订单。
+>
+> 技术根因：没有「调用台账（Ledger）」，**网络故障 = 重复下单**。
+> 实际损失：超额采购 + 供应商投诉 + 手工核查每笔订单。
+
+**场景六：医疗 AI 助手生成诊断报告，崩溃后重复写入患者记录**
+> 医疗 Agent 读取患者检查数据、调用 LLM 生成诊断建议、写入 HIS 系统。
+> 步骤 3 写入时超时，Agent 重试——**患者记录出现两条重复诊断，内容略有不同**。
+> 医生不知道该信哪条。
+>
+> 技术根因：数据库写入没有幂等保证，**超时重试 = 脏数据**。
+> 实际损失：医疗事故风险 + 手工核查 + 合规风险。
 
 ---
 
 ## 😮‍💨 Aetheris 之前的无奈
 
 ```
-你的 AI Agent：
-❌ Worker 重启 → 从头开始跑，用户等 10 分钟
-❌ 支付完成后崩溃 → 不知道付没付，钱打水漂或重复扣
-❌ 出 bug 想回放 → 不可能，只能重跑
-❌ 要人工审批 → 只能重新问用户，上下文丢失
-❌ 监管审计 → 拿不出证据，解释不清
+你的 AI Agent（每个团队都踩过的坑）：
+❌ Worker 重启      → 从头开始跑，LLM token 全部重烧，用户等 N 倍时间
+❌ 支付 API 超时    → 不知道付没付，选择重试 → 重复扣款；选择不试 → 丢单
+❌ 出 bug 想回放    → 不可能，只能重跑一遍猜逻辑
+❌ 等人工审批       → 审批通过，上下文已丢，重新问一遍用户，状态不一致
+❌ 监管来审计       → 拿不出 AI 决策证据，只有一堆 print log
+❌ 多 Agent 协作    → 某个 Agent 挂了，其他 Agent 不知道状态，整体混乱
+❌ 供应商 API 重试  → 没有幂等台账，重试 = 重复下单
+❌ 医疗/金融写入    → 超时重试写出脏数据，手工核查成本极高
 ```
 
 ---
@@ -60,14 +90,17 @@
 
 ```
 用 Aetheris 跑你的 Agent：
-✅ Worker 重启 → 从上一次成功的步骤继续，毫秒级恢复
-✅ 支付完成后崩溃 → 事件溯源，能查到"第几步完成的"
-✅ 出 bug 想回放 → 任意时间点重放，像看录像一样定位问题
-✅ 要人工审批 → 状态 park，等你 approve，从断点继续
-✅ 监管审计 → 完整决策链，step by step 的证据包
+✅ Worker 重启      → 从上一次成功的步骤继续，毫秒级恢复，LLM 结果从缓存注入不重调
+✅ 支付 API 超时    → 幂等台账（Ledger）记录调用状态，重试前先查台账，永不重复扣款
+✅ 出 bug 想回放    → 任意时间点确定性重放，像看录像一样定位问题，不触发真实 API
+✅ 等人工审批       → Job 状态 Park，保留完整上下文，approve 后无缝从断点继续
+✅ 监管来审计       → 完整不可变事件链，step by step 决策证据包，随时导出
+✅ 多 Agent 协作    → 各 Agent 独立持久化，独立恢复，互不影响
+✅ 供应商 API 重试  → 调用台账 + 幂等键，同一请求永远只执行一次
+✅ 医疗/金融写入    → 两步提交（先记录再执行），崩溃恢复走 catch-up，不产生脏数据
 ```
 
-> **不改变你写 Agent 的方式**，只用 Aetheris 托管你的 Agent，它帮你兜底可靠性。
+> **不改变你写 Agent 的方式**，只用 Aetheris 托管你的 Agent，它帮你兜底所有执行可靠性问题。
 
 ---
 
@@ -85,26 +118,33 @@
 
 ## ✨ 核心能力
 
-| 能力 | 听起来像 | 实际上解决了 |
-| ---- | -------- | ------------ |
-| **At-Most-Once** | "工具调用不重复" | 你的支付 API 再也不会被调用两次 |
-| **Crash Recovery** | "崩溃能恢复" | 跑了 2 小时的报告不会被清零 |
-| **Deterministic Replay** | "可以回放" | 出 bug 能像看录像一样定位 |
-| **Human-in-the-Loop** | "人工审批" | 大额操作等你批准再继续 |
-| **Event Sourcing** | "事件溯源" | 监管来查，你有一整条证据链 |
+| 能力 | 听起来像 | 实际上解决了 | 工作机制 |
+| ---- | -------- | ------------ | -------- |
+| **At-Most-Once** | "工具调用不重复" | 你的支付 API 再也不会被调用两次 | Invocation Ledger + Effect Store 两步提交，幂等键在崩溃前后全程追踪 |
+| **Crash Recovery** | "崩溃能恢复" | 跑了 4 小时的报告不会被清零 | 每个 Step 完成后写 Checkpoint；崩溃后下一个 Worker 从 Checkpoint 续跑，已完成 Step 从事件流注入结果 |
+| **Deterministic Replay** | "可以回放" | 出 bug 能像看录像一样定位 | Replay 时 Runner 从 Event Store 注入所有已提交结果，**不触发真实 LLM/Tool 调用** |
+| **Human-in-the-Loop** | "人工审批" | 大额操作等你批准再继续，上下文不丢 | Job 状态置为 StatusParked，计算资源释放，approve signal 到达后从断点精确恢复 |
+| **Event Sourcing** | "事件溯源" | 监管来查，你有一整条不可变证据链 | 所有 Step 状态变更追加写入 Event Store（append-only），永不修改历史，可重建任意时刻状态 |
+| **DAG 并发执行** | "并行加速" | 多个独立步骤同时跑，不互相等待 | 拓扑层内步骤并行调度，失败快速中止同层，Replay 按确定顺序重建，幂等保证不变 |
 
 ---
 
 ## 📊 什么时候用？真实场景举例
 
-| 场景 | 不用 Aetheris | 用了 Aetheris |
-| ---- | -------------- | -------------- |
-| **支付场景** | 支付完成后 Worker 崩溃，重复扣款 | 事件溯源，幂等保证，崩溃也能确认支付状态 |
-| **长任务处理** | 处理 1 万条数据，崩在最后 1 条，全部重跑 | Checkpoint 恢复，从断点继续，API 只调一次 |
-| **需要审批** | Agent 执行到一半要等审批，状态丢失 | StatusParked，审批通过后无缝从断点继续 |
-| **合规审计** | 监管来查，拿不出 Agent 决策证据 | 完整事件链，step by step 回放 |
-| **Bug 调试** | 生产出 bug，只能重跑一遍看日志猜 | 任意时间点重放执行，像看录像一样定位 |
-| **多 Agent 协作** | 一个 Agent 挂了，其他不知道状态 | 各 Agent 独立持久化，独立恢复 |
+| 场景 | 行业 | 不用 Aetheris | 用了 Aetheris |
+| ---- | ---- | ------------- | ------------- |
+| **支付/退款流程** | 金融/电商 | 支付完成后 Worker 崩溃，重复扣款或丢单 | 幂等台账 + 两步提交，崩溃也能确认支付状态 |
+| **大批量数据处理** | 合规/数据 | 处理 1 万条数据，崩在最后 1 条，全部重跑 | Checkpoint 恢复，从断点继续，LLM 不重调 |
+| **大额审批流程** | 金融/采购 | Agent 等审批时上下文丢失，重新触发所有上游查询 | StatusParked，审批通过后无缝从断点继续 |
+| **合规/监管审计** | 金融/医疗 | 监管来查，拿不出 Agent 决策证据 | 完整不可变事件链，step by step 回放 |
+| **生产 Bug 调试** | 所有行业 | 只能重跑一遍猜逻辑，触发真实 API | 确定性重放，不触发 API，精准定位问题 |
+| **多 Agent 协作** | 研究/客服 | 某个 Agent 挂了，整体状态混乱 | 各 Agent 独立持久化，独立恢复，互不影响 |
+| **供应链询价/订单** | 制造/零售 | 向 30 个供应商重发请求，导致重复下单 | Ledger 幂等键，每个供应商请求只确认一次 |
+| **医疗诊断辅助** | 医疗 | 超时重试写出重复诊断记录，产生脏数据 | 两步提交，崩溃走 catch-up，记录唯一 |
+| **法律文件生成** | 法律 | 生成合同中途崩溃，片段状态无法恢复 | 逐步 Checkpoint，从断点继续生成 |
+| **保险理赔 Agent** | 保险 | 理赔流程跨系统，一个环节失败全部重来 | DAG 并发 + 独立 Checkpoint，精确失败恢复 |
+| **内容审核流水线** | 内容平台 | 批量审核中断后无法区分哪些已处理 | Event Store 记录每条处理状态，续跑不重复 |
+| **AI 投研报告** | 金融 | 跑了几小时后因 API 限流失败，全部重来 | 已成功 Step 缓存注入，限流重试不重调 LLM |
 
 ---
 
@@ -243,23 +283,64 @@ Each step produces exactly one outcome:
 
 ---
 
+## 🔍 At-Most-Once 到底怎么保证的？
+
+这是 Aetheris 最核心也最难做对的一个能力。
+
+**问题：为什么普通 Agent 做不到 At-Most-Once？**
+
+```
+// ❌ 普通重试逻辑的陷阱
+func processRefund(orderID string) error {
+    result, err := paymentAPI.Charge(orderID)  // 调了
+    if err != nil {
+        return retry(processRefund, orderID)    // 再调！ → 重复扣款
+    }
+    saveResult(result)
+    return nil
+}
+// 崩溃发生在 Charge 成功但 saveResult 之前 → 重启后重试 → 再次扣款
+```
+
+**Aetheris 的解法：Invocation Ledger + Effect Store 两步提交**
+
+```
+Step 执行前：  Ledger.Authorize(idempotency_key) → 只允许第一次通过
+                                                 → 后续调用返回"已存在"
+Step 执行中：  Tool.Execute() → 成功后 Effect.Put(result)  ← 先持久化结果
+Step 执行后：  EventStore.Append(command_committed)         ← 再写事件
+
+崩溃恢复时：   检查 Ledger → 已授权 → 检查 Effect Store → 有结果
+              → catch-up: 直接注入结果，不重新执行 Tool
+              → 永远只扣一次款
+```
+
+**三个关键不变量：**
+1. `Ledger.Authorize` 成功 = 这个幂等键已被「预占」，后续重试直接返回已有结果
+2. `Effect.Put` 先于 `EventStore.Append` = 崩溃在两者之间时，恢复靠 catch-up 而非重执行
+3. Replay 路径绝不调用真实 Tool/LLM = 历史结果从 Event Store 注入，行为 100% 确定
+
+---
 
 ## 📈 Why This Matters
 
 ```
 LLMs made agents possible.
 Aetheris makes agents production-ready.
+
+Before Aetheris: your agent is a script.
+After Aetheris:  your agent is a durable process.
 ```
-
-
 
 | Problem               | Without Aetheris           | With Aetheris           |
 | --------------------- | -------------------------- | ----------------------- |
 | Worker crash | Restart from beginning     | Resume from checkpoint  |
-| Duplicate calls  | Possible ($$$ loss)        | Guaranteed at-most-once |
-| Debug     | Guess what happened        | Deterministic replay    |
-| Audit    | Impossible                 | Full evidence chain     |
-| Human approval  | Wastes resources | StatusParked  |
+| Duplicate API calls  | Possible ($$$ loss)        | Guaranteed at-most-once via Ledger |
+| Debug production bug  | Guess what happened        | Deterministic replay, zero real API calls |
+| Regulatory audit    | Impossible to reconstruct  | Full immutable evidence chain |
+| Human approval  | Context lost, restart needed | StatusParked, resume from exact breakpoint |
+| Multi-step long tasks | Any failure = full restart | Per-step checkpoint, granular recovery |
+| Compliance-grade tracing | No structured audit trail | Event-sourced, append-only execution history |
 
 ---
 
@@ -269,14 +350,16 @@ Aetheris makes agents production-ready.
 
 | 模板 | 解决什么问题 |
 | ---- | ------------ |
-| [**客服 Agent**](./templates/customer-service-agent/) | 用户问退货 → 调库存 → 审批退款 → 执行退款，全流程不丢状态 |
-| [**RAG 助手**](./templates/rag-assistant/) | 上传 PDF → 自动向量化 → 问答，所有步骤可重放 |
-| [**自动研究员**](./templates/autonomous-researcher/) | 丢一个主题，它自己搜、自己读、自己总结，崩了能从断点继续 |
-| [**多 Agent 辩论**](./templates/multi-agent-debate/) | 多个 Agent 协作讨论，挂了不影响整体，独立恢复 |
+| [**退款审批 Agent**](./examples/human_approval_agent/) | 用户申请退款 → 调风控 → 等审批 → 执行退款，全流程不丢状态，幂等保证不重复扣款 |
+| [**客服处理 Agent**](./examples/simple_chat_agent/) | 用户问题分类 → 调工单系统 → 通知，崩溃后从断点继续，消息不重复发送 |
+| [**RAG 研究助手**](./examples/eino_agent_with_tools/) | 上传文档 → 向量化 → 检索问答，所有步骤可重放，LLM 结果缓存 |
+| [**多 Agent 协作**](./examples/multi_agent_collaboration/) | 多个 Agent 分工协作，各自独立 Checkpoint，某 Agent 挂了不影响整体 |
+| [**计划执行 Agent**](./examples/plan_execute_agent/) | 分解目标 → DAG 执行 → 汇总结果，并行步骤加速，失败精确恢复 |
+| [**技能路由 Agent**](./examples/skill_agent/) | 根据任务类型分发给不同 Agent，全链路事件溯源，随时审计 |
 
-[**MCP Gateway**](./tools/mcp-gateway/) — 预置工具：GitHub、文件系统、网页搜索、数据库
+[**MCP Gateway**](./docs/mcp/) — 预置工具：GitHub、文件系统、网页搜索、数据库
 
-[VSCode Extension](./tools/vscode-extension/) — Code snippets & syntax highlighting
+[CLI 工具文档](./docs/guides/cli.md) — `aetheris jobs list / trace / replay` 查看、追踪、重放任务
 
 ---
 

--- a/docs/concepts/event-sourcing.md
+++ b/docs/concepts/event-sourcing.md
@@ -298,6 +298,103 @@ agent := &Agent{
 | **Job** | Agent 的一次执行任务 |
 | **Step** | Job 中的单个执行步骤 |
 | **Replay** | 从事件历史重放重建状态 |
+
+---
+
+## 深度：事件溯源如何解决 Agent 的具体问题
+
+### 问题一：不知道「支付到底成功没」
+
+传统场景：支付 API 调用成功，但写数据库之前崩溃了。重启后，数据库里没有记录，Agent 以为没付，**再调一次**。
+
+事件溯源解法：
+```
+事件流（append-only）：
+[1] JobCreated      → job_id=abc
+[2] StepStarted     → step=payment
+[3] ToolCalled      → tool=PaymentAPI, idempotency_key=abc-payment-1
+[4] ToolResult      → result={success:true, txn_id:T001}  ← 崩溃发生在这之后
+[5] StepCompleted   → step=payment  ← 这条还没写
+
+崩溃恢复时：
+Ledger 查询 idempotency_key=abc-payment-1 → 已授权
+Effect Store 查询 abc-payment-1 → 有结果 {success:true, txn_id:T001}
+→ catch-up: 写回 StepCompleted 事件
+→ 注入结果，不重新调用 PaymentAPI
+→ 支付只发生一次
+```
+
+### 问题二：「4 小时的报告跑了一半崩了」
+
+传统场景：无状态重试，从第 1 条数据重新处理，LLM 全部重调，成本翻倍。
+
+事件溯源解法：
+```
+事件流：
+[1] JobCreated
+[2] StepCompleted   → step=process_item_1
+[3] StepCompleted   → step=process_item_2
+...
+[9800] StepCompleted → step=process_item_9800
+[崩溃]
+
+恢复时：
+Scheduler 读取 Checkpoint → cursor=9800
+Runner 从 step_9801 开始
+步骤 1-9800 的 LLM 结果从 Effect Store 注入，不重新调用
+→ 只需跑剩余 200 条，成本和时间是原来的 2%
+```
+
+### 问题三：「审批等了 3 天，上下文丢了」
+
+传统场景：Agent 进程退出，所有内存状态消失，审批通过后只能重跑。
+
+事件溯源解法：
+```
+事件流：
+[1] JobCreated      → goal="退款 ¥500,000"
+[2] StepCompleted   → step=query_order, result={...订单详情...}
+[3] StepCompleted   → step=risk_check,  result={...风控结果...}
+[4] JobParked       → reason="等待人工审批", wait_key="approval-abc"
+[3 天后]
+[5] SignalReceived  → wait_key="approval-abc", approved=true, by=manager@corp.com
+
+恢复时：
+Runner 读取事件流
+步骤 query_order、risk_check 的结果从 Event Store 注入 → 不重新查询
+从 step=execute_refund 继续
+审批决策本身也被记录在事件流中 → 完整审计链
+```
+
+### 问题四：「监管来查，说不清 AI 做了什么」
+
+传统场景：只有 print 日志，无法还原推理链，无法证明 AI 行为合规。
+
+事件溯源解法：
+```bash
+# 导出完整证据包
+aetheris trace job_xyz789 --format evidence-package > audit.json
+
+# audit.json 包含：
+# - 输入：用户请求原文
+# - 每个 ToolCalled 的入参和返回值（精确时间戳）
+# - 每个 LLMGenerated 的 prompt 和 completion
+# - 每个决策节点的状态变更
+# - 最终输出和 Job 完成时间
+# - 操作者信息（由哪个 Worker、哪个 attempt 执行）
+```
+
+---
+
+## 不使用事件溯源会怎样？
+
+| 场景 | 无事件溯源 | 有事件溯源 |
+|------|-----------|-----------|
+| Worker 崩溃后 | 从头开始，或手工恢复 | 从最近 Checkpoint 精确续跑 |
+| API 重复调用 | 无法检测，依赖下游幂等 | Ledger + Effect 双重保护 |
+| 审计要求 | 无法重建，只有碎片日志 | 完整不可变事件链，随时导出 |
+| 生产 bug 调试 | 重跑触发真实 API，有副作用 | Deterministic Replay，零副作用 |
+| 大额操作审批 | 上下文丢失，重新查所有数据 | 精确断点恢复，零数据重查 |
 | **Lease Fencing** | 防止分布式环境下的双跑 |
 
 事件溯源让 Aetheris 成为 **"Temporal for Agents"** — 一个真正可靠、可追溯、可恢复的 AI Agent 运行时。

--- a/docs/guides/runtime-guarantees.md
+++ b/docs/guides/runtime-guarantees.md
@@ -635,3 +635,134 @@ Expected:
 - [design/step-contract.md](../design/step-contract.md) — How to write correct steps
 - [design/effect-system.md](../design/effect-system.md) — Effect Store, replay, two-phase commit
 - [design/runtime-contract.md](../design/runtime-contract.md) — Blocking, epoch, attempt_id validation
+
+---
+
+## 场景深化：At-Most-Once 在真实业务中如何落地
+
+下面三个场景展示 At-Most-Once 保证在真实业务环境下的完整工作流，帮助开发者理解「为什么这样设计」以及「怎么验证它确实工作了」。
+
+---
+
+### 场景 A：支付 Agent 崩溃恢复（金融电商）
+
+**业务背景**：电商退款 Agent 需要调用第三方支付 SDK 发起退款，退款金额最高 ¥100,000。
+
+**崩溃时序**：
+
+```
+Worker A 执行 step=refund_execute：
+  T=0ms:   Tool.Execute(PaymentSDK.Refund, idempotency_key="job-abc-refund-1") 开始
+  T=200ms: 第三方支付 SDK 返回成功 {txn_id: "TXN9001", status: "success"}
+  T=201ms: Effect.Put("job-abc-refund-1", {txn_id: "TXN9001"})  ← 持久化结果
+  T=202ms: Worker 进程被 OOM Killer 强杀                         ← 崩溃点
+  T=203ms: EventStore.Append(command_committed) 未执行
+
+Scheduler 等待 30s 租约过期：
+  T=30s:   Reclaim：job 状态重置为 Pending
+
+Worker B 认领：
+  T=30.1s: Replay 已完成步骤
+  T=30.2s: 到达 step=refund_execute
+  T=30.3s: Ledger.Authorize("job-abc-refund-1") → 已存在
+  T=30.4s: Effect Store 查询 → 有结果 {txn_id: "TXN9001"}
+  T=30.5s: catch-up: Append(command_committed) ← 补写事件
+  T=30.6s: 注入结果，继续下一步（发送确认邮件）
+
+最终结果：退款只执行了一次（TXN9001），没有重复扣款。
+```
+
+**如何验证**：
+
+```bash
+# 查看 Ledger 只有一条 committed 记录
+curl http://localhost:8080/api/jobs/job-abc/trace | \
+  jq '[.events[] | select(.type=="tool_invocation_finished")] | length'
+# 预期输出: 1
+
+# 查看 Effect Store 的 catch-up 记录
+curl http://localhost:8080/api/jobs/job-abc/replay | \
+  jq '.events[] | select(.type=="command_committed" and .step=="refund_execute")'
+# 预期: 只有一条，timestamp 在原始崩溃时间之后（catch-up 写入）
+```
+
+---
+
+### 场景 B：供应链询价 Agent 并发调用 30 个供应商（制造业）
+
+**业务背景**：采购 Agent 并发向 30 个供应商发送 RFQ（询价单），每个 API 调用对应一个独立 Step。网络抖动导致部分请求超时，Worker 在重试中途崩溃。
+
+**关键设计**：每个供应商调用使用独立 idempotency_key：
+
+```go
+// Tool 实现示例
+func (t *SendRFQTool) Execute(ctx context.Context, sess *session.Session, input map[string]any, state interface{}) (any, error) {
+    supplierID := input["supplier_id"].(string)
+    
+    // idempotency_key 由 runtime 从 ctx 提供，绑定到 (jobID, stepID)
+    // 相同的 (job, step, supplier) 组合永远只调用一次
+    key := effects.StepIdempotencyKeyForExternal(ctx, sess.JobID, sess.StepID)
+    
+    resp, err := t.rfqClient.SendRFQ(ctx, supplierID, input["rfq"].(RFQPayload), key)
+    if err != nil {
+        return nil, err
+    }
+    return resp, nil
+}
+```
+
+**崩溃恢复后的状态**：
+
+```
+崩溃前已完成：供应商 1-18（StepCompleted 在事件流中）
+崩溃时进行中：供应商 19（Ledger 有 Authorize，Effect Store 有结果）
+崩溃时未开始：供应商 20-30
+
+恢复后：
+- 供应商 1-18：从事件流注入结果，API 不重调
+- 供应商 19：catch-up 补写，API 不重调
+- 供应商 20-30：正常执行，首次调用
+
+结果：30 个供应商各收到且仅收到一份 RFQ。
+```
+
+---
+
+### 场景 C：医疗 AI 诊断报告写入 HIS（医疗）
+
+**业务背景**：AI 分析患者检查数据后，生成结构化诊断建议并写入 HIS 系统。HIS API 本身不提供幂等保证，重复写入会创建两条诊断记录。
+
+**两步提交保护**：
+
+```
+Step=generate_and_write_diagnosis：
+  阶段 1（Effect.Put）：
+    LLM 生成诊断建议 → 内容持久化到 Effect Store
+    key="job-p001-diagnosis-v1"
+    value={diagnosis: "建议复查...", generated_at: "2026-05-07T10:30:00Z"}
+
+  阶段 2（执行写入）：
+    使用 Effect Store 中的内容调用 HIS API
+    HIS.WriteRecord(patient_id="P001", content=effect_value)
+    → 成功
+
+  阶段 3（EventStore.Append）：
+    Append(command_committed, step=generate_and_write_diagnosis)
+
+如果崩溃发生在阶段 2 和 3 之间：
+  恢复时：Effect Store 查询 → 有内容 → catch-up 补写事件
+  HIS API：带同一 idempotency_key 重发（HIS 层通过 key 去重）
+  结果：患者记录唯一，诊断内容一致
+```
+
+---
+
+### 场景间共同规律
+
+| 场景 | 关键保护机制 | 崩溃后恢复路径 |
+|------|------------|-------------|
+| 支付退款 | Ledger + Effect Store | catch-up 注入，不重调支付 SDK |
+| 供应链 RFQ | 独立 idempotency_key per 供应商 | 已完成的 step 注入，未完成的继续 |
+| 医疗 HIS 写入 | 两步提交（先 Effect.Put 再 Append） | Effect Store 有内容，补写事件不重调 |
+
+**核心不变量**：只要 Effect.Put 成功，就算 EventStore.Append 还没执行，恢复路径也能通过 catch-up 保证 Tool 不被重新执行。

--- a/docs/strategy-and-user-stories.md
+++ b/docs/strategy-and-user-stories.md
@@ -17,15 +17,93 @@ As an enterprise application developer, I need to build workflows such as travel
 I need the agent to pause at critical nodes, release compute resources, and wait for human approval.  
 After approval, execution must resume losslessly from the breakpoint without re-spending previous LLM tokens.
 
+**Root problem**: Most agent frameworks treat execution as a single in-memory call stack. Pausing for days means losing all intermediate state. Re-running consumes LLM tokens, re-triggers upstream API calls, and may produce different results.
+
+**Aetheris solution**: `StatusParked` persists the full execution graph to durable storage. The `wait_signal` node blocks on a named signal. When `approve` arrives via API or CLI, the scheduler re-leases the Job and the Runner resumes from the exact checkpoint — no data re-fetched, no LLM re-called, no state inconsistency.
+
+**Acceptance criteria**:
+- Agent can pause mid-DAG for arbitrarily long durations (hours, days)
+- Resuming does not re-invoke completed steps
+- All intermediate state (query results, LLM decisions) is preserved and injected on resume
+- Evidence of approval decision is recorded in the event stream
+
+---
+
 ### 2) Financial and Legal Compliance
 
 As a financial compliance/risk engineer, I need an AI agent for diff analysis and anomaly detection.  
 Every API call and reasoning decision must be recorded in an immutable log so we can fully reconstruct and explain why the AI acted in a certain way during audits.
 
+**Root problem**: Agent "logs" are typically unstructured stdout lines that cannot be replayed, correlated, or cryptographically attested. When regulators ask "why did the AI recommend product X?", there is no structured answer.
+
+**Aetheris solution**: Every step transition (`StepStarted`, `StepCompleted`, `ToolCalled`, `ToolResult`, `LLMGenerated`) is appended to an event-sourced Job Store. The Evidence Package API exports a signed, structured proof package with full causal chain from input to output. Deterministic replay re-runs the Agent against the recorded event stream without touching live APIs, producing an identical decision trace.
+
+**Acceptance criteria**:
+- Complete event log from job creation to completion, append-only, never modified
+- Replay produces same outputs as original run (no LLM/Tool re-calls)
+- Evidence package exportable in auditor-readable format
+- Timestamps and attempt IDs on every event for forensic attribution
+
+---
+
 ### 3) Data Privacy and Local Deployment
 
 As an enterprise architect focused on data sovereignty, I need a lightweight agent engine that runs in private networks or air-gapped environments.  
 Core business context must stay local, avoiding continuous upload to external hosted platforms.
+
+**Root problem**: Cloud-first agent runtimes send execution traces, prompts, and intermediate results to vendor backends. For regulated industries (healthcare, finance, defense), this is a hard blocker.
+
+**Aetheris solution**: Embedded mode runs with zero external dependencies — SQLite-backed event store, in-process scheduler, local effect store. No phone-home, no external telemetry. Can be deployed in K8s within a private VPC or even on an air-gapped machine.
+
+**Acceptance criteria**:
+- Fully functional with only local resources (no PostgreSQL/Redis required in embedded mode)
+- No outbound network calls to vendor infrastructure
+- Configuration schema supports private LLM endpoints (Ollama, private Azure endpoints)
+
+---
+
+### 4) Supply Chain and Multi-System Orchestration
+
+As a procurement engineer, I need an Agent to send RFQs to 30+ suppliers, confirm responses, and create purchase orders. Any API call to a confirmed supplier must never be duplicated — duplicate POs cost real money.
+
+**Root problem**: When orchestrating tens of external APIs, network failures and partial successes create ambiguity. Without per-call idempotency tracking, retry = duplicate order.
+
+**Aetheris solution**: Each supplier API call uses a unique `idempotency_key` derived from `(jobID, stepID, supplierID)`. The Invocation Ledger records authorization per key. On retry, the Ledger returns "already committed" and injects the recorded result — the real supplier API is never called again.
+
+**Acceptance criteria**:
+- Each supplier API called at most once per job, regardless of retries or worker crashes
+- Partial failure (some suppliers confirmed, some not) recovers from exact state without re-confirming already-confirmed suppliers
+- Full audit log of which supplier was contacted when, what was requested, what was returned
+
+---
+
+### 5) Medical AI and High-Stakes Write Operations
+
+As a healthcare application developer, I need an AI diagnostic assistant to analyze patient records and write structured summaries to the HIS system. Duplicate writes must be impossible — two conflicting diagnostic summaries are a patient safety risk.
+
+**Root problem**: Idempotency at the application layer is hard when the write operation is expensive (LLM-generated) and the HIS API does not provide native deduplication. Retry-on-timeout creates duplicate records.
+
+**Aetheris solution**: LLM generation is wrapped in the Effect Store: before the write, `Effect.Put(key, result)` persists the generated content. Then `EventStore.Append(command_committed)` finalizes. On crash between the two, the catch-up path reads from Effect Store and re-applies without re-generating. The HIS write receives a stable idempotency key, preventing duplicate records.
+
+**Acceptance criteria**:
+- LLM-generated content is persisted before being applied to HIS
+- Crash between generation and write does not cause re-generation or duplicate write
+- Every write attempt is traceable to a specific job, step, and idempotency key
+
+---
+
+### 6) Regulatory-Grade Audit for AI Decision Agents
+
+As a risk officer in a bank, I need the AI agent's complete decision history — every data point queried, every model output, every action taken — to be available on demand for regulatory examination within 24 hours of any incident.
+
+**Root problem**: Agent execution is ephemeral. Once the process exits, the reasoning chain is gone. Reconstruction from logs is incomplete and non-deterministic.
+
+**Aetheris solution**: The append-only Event Store is the source of truth. Every `ToolCalled`, `ToolResult`, `LLMGenerated`, and `StepCompleted` event is immutable once written. The `aetheris trace <job_id>` CLI and `/api/jobs/:id/events` API expose the full chain. The Evidence Package can be exported as a tamper-evident audit bundle with cryptographic consistency checks.
+
+**Acceptance criteria**:
+- Full execution history retrievable for any job within seconds
+- Replay produces identical reasoning trace (no drift)
+- Evidence package includes input context, intermediate states, and final output with timestamps
 
 ## User Story to Capability Mapping
 


### PR DESCRIPTION
- README: 扩展崩溃场景至6个，补充技术根因和实际损失分析 新增供应链重复下单、医疗写入脏数据场景
- README: 核心能力表格新增工作机制列，说明底层实现原理
- README: 使用场景扩展至12行，覆盖金融/医疗/法律/保险等行业
- README: 新增 At-Most-Once 工作机制深度解析章节（含代码示例）
- strategy-and-user-stories: 用户故事从3个扩展到6个 每个故事新增 Root problem / Aetheris solution / Acceptance criteria 新增供应链询价、医疗AI助手、监管审计三个故事
- docs/concepts/event-sourcing: 新增事件溯源解决具体业务问题章节 映射4类典型问题（支付/批处理/审批/审计）到事件流解法
- docs/guides/runtime-guarantees: 新增 At-Most-Once 真实业务落地章节 场景A支付退款崩溃恢复、场景B供应链并发RFQ、场景C医疗HIS两步提交 每个场景含崩溃时序/代码示例/验证命令

## Summary

Describe the change and why it is needed.

## Changes

- 

## Validation

- [ ] `go test ./...`
- [ ] `go build ./...`
- [ ] docs updated when behavior changed

## Compatibility / Risk

Call out breaking changes, migrations, or runtime risks.

## Related Issues

Link related issues (e.g. `Closes #123`).

