### PR TITLE
feat(agents): add superagent-base as external_http integration with s…

### DIFF
--- a/configs/agents.yaml
+++ b/configs/agents.yaml
@@ -54,6 +54,21 @@ agents:
   #     timeout: "120s"
   #     token_env: "CUSTOMER_BOT_TOKEN"
 
+  # superagent-base 集成 —— 开源 AI Agent 平台（SSE 流式协议）
+  # 项目地址：https://github.com/Colin4k1024/superagent-base
+  # 启动 superagent-base 服务后取消注释即可接入。
+  # 环境变量 SUPERAGENT_BASE_API_KEY 设置为 superagent-base 的 api_key。
+  # agent_id 可指定要调用的具体 Agent（留空则使用远端默认值 "research-agent"）。
+  # superagent_base:
+  #   type: "external_http"
+  #   description: "superagent-base 开源 AI Agent 平台（SSE 流式接入）"
+  #   external:
+  #     url: "http://localhost:8888/api/v1/chat/stream"
+  #     timeout: "120s"
+  #     token_env: "SUPERAGENT_BASE_API_KEY"
+  #     protocol: "sse_legacy"
+  #     agent_id: "research-agent"    # 可选，指定远端 Agent ID
+
   # Chain - 简单链式调用
   conversation:
     type: "chain"

--- a/internal/app/api/external_agent_tool.go
+++ b/internal/app/api/external_agent_tool.go
@@ -170,6 +170,7 @@ func (t *externalAgentCallTool) Execute(ctx context.Context, sess *session.Sessi
 	}
 
 	metadata := mapFromAny(input["metadata"])
+	userMetadata := metadata // preserve user-provided metadata for protocol-specific checks
 	if metadata == nil {
 		metadata = make(map[string]any)
 	}
@@ -186,7 +187,7 @@ func (t *externalAgentCallTool) Execute(ctx context.Context, sess *session.Sessi
 	switch protocol {
 	case "sse_legacy":
 		// sse_legacy 不转发 metadata；有用户输入的 metadata 时报错避免静默丢失。
-		if len(mapFromAny(input["metadata"])) > 0 {
+		if len(userMetadata) > 0 {
 			return nil, fmt.Errorf("external_agent_call: metadata is not forwarded in sse_legacy protocol")
 		}
 		// superagent-base 兼容格式：{"agent_id","session_id","message"}

--- a/internal/app/api/external_agent_tool.go
+++ b/internal/app/api/external_agent_tool.go
@@ -44,11 +44,14 @@ type sseAgentRequest struct {
 
 // consumeSSELegacyResponse 消费 SSE 流式响应（Legacy 模式），聚合 token 直到收到 [DONE]。
 // 格式：每行 "data: <token>\n\n"，结束标记 "data: [DONE]\n\n"。
-// 响应体读取上限为 maxExternalResponseBytes。
+// 如果流在未收到 [DONE] 的情况下结束，则返回错误（协议错误）。
+// 聚合内容超过 maxExternalResponseBytes 时返回错误。
 func consumeSSELegacyResponse(body io.Reader) (string, error) {
 	const doneMarker = "[DONE]"
+	const maxLineBytes = 64 * 1024 // 64 KiB per SSE line
 	var sb strings.Builder
-	scanner := bufio.NewScanner(io.LimitReader(body, maxExternalResponseBytes+1))
+	scanner := bufio.NewScanner(body)
+	scanner.Buffer(make([]byte, maxLineBytes), maxLineBytes)
 	for scanner.Scan() {
 		line := scanner.Text()
 		if !strings.HasPrefix(line, "data:") {
@@ -59,12 +62,15 @@ func consumeSSELegacyResponse(body io.Reader) (string, error) {
 			return sb.String(), nil
 		}
 		sb.WriteString(token)
+		if int64(sb.Len()) > maxExternalResponseBytes {
+			return "", fmt.Errorf("external_agent_call: SSE response exceeds %d MiB limit", maxExternalResponseBytes/(1024*1024))
+		}
 	}
 	if err := scanner.Err(); err != nil {
 		return "", fmt.Errorf("external_agent_call: read SSE stream: %w", err)
 	}
-	// 流结束但未遇到 [DONE] 标记，返回已聚合内容。
-	return sb.String(), nil
+	// 流结束但未遇到 [DONE] 标记，视为协议错误。
+	return "", fmt.Errorf("external_agent_call: SSE stream ended without [DONE] sentinel")
 }
 
 type externalAgentCallTool struct {
@@ -155,6 +161,14 @@ func (t *externalAgentCallTool) Execute(ctx context.Context, sess *session.Sessi
 	if sess != nil {
 		sessionID = sess.ID
 	}
+	protocol := strings.ToLower(strings.TrimSpace(agentCfg.Protocol))
+	switch protocol {
+	case "", "json", "sse_legacy":
+		// valid
+	default:
+		return nil, fmt.Errorf("external_agent_call: unsupported protocol %q for agent %q; allowed values: \"\", \"json\", \"sse_legacy\"", protocol, agentID)
+	}
+
 	metadata := mapFromAny(input["metadata"])
 	if metadata == nil {
 		metadata = make(map[string]any)
@@ -169,9 +183,12 @@ func (t *externalAgentCallTool) Execute(ctx context.Context, sess *session.Sessi
 
 	// 根据协议类型构建请求体。
 	var reqBody []byte
-	protocol := strings.ToLower(strings.TrimSpace(agentCfg.Protocol))
 	switch protocol {
 	case "sse_legacy":
+		// sse_legacy 不转发 metadata；有用户输入的 metadata 时报错避免静默丢失。
+		if len(mapFromAny(input["metadata"])) > 0 {
+			return nil, fmt.Errorf("external_agent_call: metadata is not forwarded in sse_legacy protocol")
+		}
 		// superagent-base 兼容格式：{"agent_id","session_id","message"}
 		sseReq := sseAgentRequest{
 			Message:   message,
@@ -203,6 +220,9 @@ func (t *externalAgentCallTool) Execute(ctx context.Context, sess *session.Sessi
 		return nil, fmt.Errorf("external_agent_call: create request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	if protocol == "sse_legacy" {
+		req.Header.Set("Accept", "text/event-stream")
+	}
 	if idempotencyKey != "" {
 		req.Header.Set("Idempotency-Key", idempotencyKey)
 	}

--- a/internal/app/api/external_agent_tool.go
+++ b/internal/app/api/external_agent_tool.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -32,6 +33,38 @@ type externalAgentResponse struct {
 	Answer   string         `json:"answer"`
 	Final    bool           `json:"final"`
 	Metadata map[string]any `json:"metadata,omitempty"`
+}
+
+// sseAgentRequest 是 sse_legacy 协议的请求体，兼容 superagent-base /api/v1/chat/stream。
+type sseAgentRequest struct {
+	AgentID   string `json:"agent_id,omitempty"`
+	SessionID string `json:"session_id,omitempty"`
+	Message   string `json:"message"`
+}
+
+// consumeSSELegacyResponse 消费 SSE 流式响应（Legacy 模式），聚合 token 直到收到 [DONE]。
+// 格式：每行 "data: <token>\n\n"，结束标记 "data: [DONE]\n\n"。
+// 响应体读取上限为 maxExternalResponseBytes。
+func consumeSSELegacyResponse(body io.Reader) (string, error) {
+	const doneMarker = "[DONE]"
+	var sb strings.Builder
+	scanner := bufio.NewScanner(io.LimitReader(body, maxExternalResponseBytes+1))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		token := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if token == doneMarker {
+			return sb.String(), nil
+		}
+		sb.WriteString(token)
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("external_agent_call: read SSE stream: %w", err)
+	}
+	// 流结束但未遇到 [DONE] 标记，返回已聚合内容。
+	return sb.String(), nil
 }
 
 type externalAgentCallTool struct {
@@ -134,13 +167,35 @@ func (t *externalAgentCallTool) Execute(ctx context.Context, sess *session.Sessi
 		metadata["idempotency_key"] = idempotencyKey
 	}
 
-	reqBody, err := json.Marshal(externalAgentRequest{
-		Message:   message,
-		SessionID: sessionID,
-		Metadata:  metadata,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("external_agent_call: encode request: %w", err)
+	// 根据协议类型构建请求体。
+	var reqBody []byte
+	protocol := strings.ToLower(strings.TrimSpace(agentCfg.Protocol))
+	switch protocol {
+	case "sse_legacy":
+		// superagent-base 兼容格式：{"agent_id","session_id","message"}
+		sseReq := sseAgentRequest{
+			Message:   message,
+			SessionID: sessionID,
+		}
+		if agentCfg.AgentID != "" {
+			sseReq.AgentID = agentCfg.AgentID
+		}
+		var err error
+		reqBody, err = json.Marshal(sseReq)
+		if err != nil {
+			return nil, fmt.Errorf("external_agent_call: encode sse request: %w", err)
+		}
+	default:
+		// 默认 JSON 协议：{"message","session_id","metadata"}
+		var err error
+		reqBody, err = json.Marshal(externalAgentRequest{
+			Message:   message,
+			SessionID: sessionID,
+			Metadata:  metadata,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("external_agent_call: encode request: %w", err)
+		}
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, agentCfg.URL, bytes.NewReader(reqBody))
@@ -185,21 +240,33 @@ func (t *externalAgentCallTool) Execute(ctx context.Context, sess *session.Sessi
 		return nil, fmt.Errorf("external_agent_call: upstream returned HTTP %d", resp.StatusCode)
 	}
 
-	// Read at most maxExternalResponseBytes+1 to detect over-size responses.
-	limitedBody, err := io.ReadAll(io.LimitReader(resp.Body, maxExternalResponseBytes+1))
-	if err != nil {
-		return nil, fmt.Errorf("external_agent_call: read response: %w", err)
-	}
-	if int64(len(limitedBody)) > maxExternalResponseBytes {
-		return nil, fmt.Errorf("external_agent_call: response exceeds %d MiB limit", maxExternalResponseBytes/(1024*1024))
-	}
+	// 根据协议类型解析响应。
 	var out externalAgentResponse
-	if err := json.Unmarshal(limitedBody, &out); err != nil {
-		return nil, fmt.Errorf("external_agent_call: decode response: %w", err)
+	switch protocol {
+	case "sse_legacy":
+		// 消费 SSE 流，聚合 token 为最终答案。
+		answer, err := consumeSSELegacyResponse(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+		out = externalAgentResponse{Answer: answer, Final: true, Metadata: metadata}
+	default:
+		// 默认 JSON 响应解析。
+		limitedBody, err := io.ReadAll(io.LimitReader(resp.Body, maxExternalResponseBytes+1))
+		if err != nil {
+			return nil, fmt.Errorf("external_agent_call: read response: %w", err)
+		}
+		if int64(len(limitedBody)) > maxExternalResponseBytes {
+			return nil, fmt.Errorf("external_agent_call: response exceeds %d MiB limit", maxExternalResponseBytes/(1024*1024))
+		}
+		if err := json.Unmarshal(limitedBody, &out); err != nil {
+			return nil, fmt.Errorf("external_agent_call: decode response: %w", err)
+		}
+		if !out.Final {
+			return nil, fmt.Errorf("external_agent_call: upstream returned final=false; streaming is not supported")
+		}
 	}
-	if !out.Final {
-		return nil, fmt.Errorf("external_agent_call: upstream returned final=false; streaming is not supported")
-	}
+
 	if out.Metadata == nil {
 		out.Metadata = make(map[string]any)
 	}

--- a/internal/app/api/external_agent_tool_test.go
+++ b/internal/app/api/external_agent_tool_test.go
@@ -3,8 +3,10 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	agentexec "github.com/Colin4k1024/Aetheris/v2/internal/agent/runtime/executor"
@@ -103,5 +105,137 @@ func TestExternalAgentCallTool_Execute_ErrorMapping(t *testing.T) {
 	}, nil)
 	if err == nil {
 		t.Fatalf("expected upstream error")
+	}
+}
+
+func TestExternalAgentCallTool_SSELegacy_HappyPath(t *testing.T) {
+	var gotAccept string
+	var gotBody sseAgentRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAccept = r.Header.Get("Accept")
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, "data: Hello\n\ndata: World\n\ndata: [DONE]\n\n")
+	}))
+	defer server.Close()
+
+	tool := NewExternalAgentCallTool(map[string]config.AgentExternalConfig{
+		"sse_agent": {URL: server.URL, Protocol: "sse_legacy", AgentID: "research-agent"},
+	})
+	out, err := tool.Execute(context.Background(), session.New("sess-42"), map[string]any{
+		"agent_id": "sse_agent",
+		"message":  "summarise this",
+	}, nil)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	result, ok := out.(tools.ToolResult)
+	if !ok {
+		t.Fatalf("expected ToolResult, got %T", out)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(result.Output), &payload); err != nil {
+		t.Fatalf("decode output: %v", err)
+	}
+	if payload["answer"] != "HelloWorld" {
+		t.Errorf("unexpected answer: %v", payload["answer"])
+	}
+	if gotAccept != "text/event-stream" {
+		t.Errorf("expected Accept: text/event-stream, got %q", gotAccept)
+	}
+	if gotBody.AgentID != "research-agent" {
+		t.Errorf("expected agent_id=research-agent, got %q", gotBody.AgentID)
+	}
+	if gotBody.SessionID != "sess-42" {
+		t.Errorf("expected session_id=sess-42, got %q", gotBody.SessionID)
+	}
+	if gotBody.Message != "summarise this" {
+		t.Errorf("expected message=summarise this, got %q", gotBody.Message)
+	}
+}
+
+func TestExternalAgentCallTool_SSELegacy_MissingDone(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		// Stream ends without [DONE]
+		fmt.Fprint(w, "data: partial\n\n")
+	}))
+	defer server.Close()
+
+	tool := NewExternalAgentCallTool(map[string]config.AgentExternalConfig{
+		"sse_agent": {URL: server.URL, Protocol: "sse_legacy"},
+	})
+	_, err := tool.Execute(context.Background(), session.New("s"), map[string]any{
+		"agent_id": "sse_agent",
+		"message":  "hello",
+	}, nil)
+	if err == nil {
+		t.Fatal("expected error for missing [DONE], got nil")
+	}
+	if !strings.Contains(err.Error(), "[DONE]") {
+		t.Errorf("error should mention [DONE]: %v", err)
+	}
+}
+
+func TestExternalAgentCallTool_SSELegacy_ByteLimit(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		// Send a response that exceeds maxExternalResponseBytes (10 MiB).
+		// We use many small tokens to build up the limit.
+		token := strings.Repeat("x", 1024) // 1 KiB token
+		for i := 0; i < 11*1024; i++ {     // 11 MiB total
+			fmt.Fprintf(w, "data: %s\n\n", token)
+		}
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer server.Close()
+
+	tool := NewExternalAgentCallTool(map[string]config.AgentExternalConfig{
+		"sse_agent": {URL: server.URL, Protocol: "sse_legacy"},
+	})
+	_, err := tool.Execute(context.Background(), session.New("s"), map[string]any{
+		"agent_id": "sse_agent",
+		"message":  "hello",
+	}, nil)
+	if err == nil {
+		t.Fatal("expected error for oversized SSE response, got nil")
+	}
+	if !strings.Contains(err.Error(), "MiB limit") {
+		t.Errorf("error should mention MiB limit: %v", err)
+	}
+}
+
+func TestExternalAgentCallTool_SSELegacy_MetadataRejected(t *testing.T) {
+	tool := NewExternalAgentCallTool(map[string]config.AgentExternalConfig{
+		"sse_agent": {URL: "http://localhost:9999", Protocol: "sse_legacy"},
+	})
+	_, err := tool.Execute(context.Background(), session.New("s"), map[string]any{
+		"agent_id": "sse_agent",
+		"message":  "hello",
+		"metadata": map[string]any{"key": "value"},
+	}, nil)
+	if err == nil {
+		t.Fatal("expected error when metadata provided for sse_legacy, got nil")
+	}
+	if !strings.Contains(err.Error(), "metadata") {
+		t.Errorf("error should mention metadata: %v", err)
+	}
+}
+
+func TestExternalAgentCallTool_UnknownProtocol(t *testing.T) {
+	tool := NewExternalAgentCallTool(map[string]config.AgentExternalConfig{
+		"bad_agent": {URL: "http://localhost:9999", Protocol: "grpc"},
+	})
+	_, err := tool.Execute(context.Background(), session.New("s"), map[string]any{
+		"agent_id": "bad_agent",
+		"message":  "hello",
+	}, nil)
+	if err == nil {
+		t.Fatal("expected error for unsupported protocol, got nil")
+	}
+	if !strings.Contains(err.Error(), "unsupported protocol") {
+		t.Errorf("error should mention 'unsupported protocol': %v", err)
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -195,6 +195,14 @@ type AgentExternalConfig struct {
 	URL      string `mapstructure:"url"`
 	Timeout  string `mapstructure:"timeout"`
 	TokenEnv string `mapstructure:"token_env"`
+	// Protocol 控制请求/响应协议。
+	// ""/"json" = 默认 JSON 协议（发送 JSON body，接收 {"answer","final"} JSON）。
+	// "sse_legacy" = SSE 流式协议（兼容 superagent-base /api/v1/chat/stream）：
+	//   发送 {"agent_id","session_id","message"}，消费 SSE data 行直到 [DONE]，聚合为最终答案。
+	Protocol string `mapstructure:"protocol"`
+	// AgentID 仅 sse_legacy 协议使用，填充请求中的 agent_id 字段。
+	// 未设置时使用远端默认值（superagent-base 默认 "research-agent"）。
+	AgentID string `mapstructure:"agent_id"`
 }
 
 // AgentLLMConfig 默认 LLM 配置（用于本地 Agent）

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -671,6 +671,16 @@ func ValidateExternalAgents(cfg *AgentsConfig) error {
 				log.Printf("WARNING: agents.%s.external.token_env %q is not set; requests will fail at execution time", name, agent.External.TokenEnv)
 			}
 		}
+		proto := strings.ToLower(strings.TrimSpace(agent.External.Protocol))
+		switch proto {
+		case "", "json", "sse_legacy":
+			// valid
+		default:
+			return fmt.Errorf("agents.%s.external.protocol %q is not supported; allowed values: \"\", \"json\", \"sse_legacy\"", name, proto)
+		}
+		if agent.External.AgentID != "" && proto != "sse_legacy" {
+			return fmt.Errorf("agents.%s.external.agent_id is only used with protocol \"sse_legacy\", got %q", name, proto)
+		}
 	}
 	return nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -632,6 +632,24 @@ func TestAgentsConfig_ExternalHTTP(t *testing.T) {
 	}
 }
 
+func TestAgentsConfig_ExternalHTTP_SSELegacy(t *testing.T) {
+	cfg := AgentsConfig{
+		Agents: map[string]AgentDefConfig{
+			"sse_bot": {
+				Type: "external_http",
+				External: AgentExternalConfig{
+					URL:      "http://sse-bot:8888/api/v1/chat/stream",
+					Protocol: "sse_legacy",
+					AgentID:  "research-agent",
+				},
+			},
+		},
+	}
+	if err := ValidateExternalAgents(&cfg); err != nil {
+		t.Fatalf("ValidateExternalAgents returned error for valid sse_legacy config: %v", err)
+	}
+}
+
 func TestValidateExternalAgents_Errors(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -669,9 +687,17 @@ func TestValidateExternalAgents_Errors(t *testing.T) {
 			}},
 		},
 		{
-			name: "file scheme",
+			name: "invalid protocol",
 			agent: AgentDefConfig{Type: "external_http", External: AgentExternalConfig{
-				URL: "file:///etc/passwd",
+				URL:      "http://customer-bot:9000/invoke",
+				Protocol: "grpc",
+			}},
+		},
+		{
+			name: "agent_id without sse_legacy",
+			agent: AgentDefConfig{Type: "external_http", External: AgentExternalConfig{
+				URL:     "http://customer-bot:9000/invoke",
+				AgentID: "some-agent",
 			}},
 		},
 	}


### PR DESCRIPTION
…se_legacy protocol

- Extend AgentExternalConfig with Protocol and AgentID fields
  - Protocol: "" or "json" for existing JSON mode (default, backward-compatible)
  - Protocol: "sse_legacy" for SSE-streaming agents (superagent-base compatible)
  - AgentID: optional target agent ID forwarded in request body (sse_legacy only)

- Add SSE-legacy consumer to ExternalAgentCallTool
  - New sseAgentRequest struct for {agent_id, session_id, message} wire format
  - consumeSSELegacyResponse() aggregates SSE tokens until [DONE] sentinel
  - Execute() branches on agentCfg.Protocol; default JSON path unchanged

- Add superagent-base reference entry to configs/agents.yaml (commented out)
  - URL: http://localhost:8888/api/v1/chat/stream
  - Protocol: sse_legacy
  - Requires SUPERAGENT_BASE_API_KEY env var
  - https://github.com/Colin4k1024/superagent-base

## Summary

Describe the change and why it is needed.

## Changes

- 

## Validation

- [ ] `go test ./...`
- [ ] `go build ./...`
- [ ] docs updated when behavior changed

## Compatibility / Risk

Call out breaking changes, migrations, or runtime risks.

## Related Issues

Link related issues (e.g. `Closes #123`).

