### PR TITLE
fix(config): add conversation agent to api.yaml to fix release gate CI

### DIFF
--- a/configs/api.yaml
+++ b/configs/api.yaml
@@ -188,3 +188,15 @@ mcp:
     #   headers:
     #     Authorization: "Bearer ${MCP_TOKEN}"
     #   timeout: "30s"
+
+# 预定义 Agent（与 configs/agents.yaml 中的 agents 对应，api.yaml 加载时注册）
+agents:
+  agents:
+    conversation:
+      type: "react"
+      description: "简单对话智能体，用于性能基准测试"
+      llm: "default"
+      max_iterations: 5
+      tools: []
+      system_prompt: |
+        You are a helpful conversational assistant. Respond concisely and clearly.


### PR DESCRIPTION
## 问题

Release Gates CI 的性能测试全部返回 `HTTP 404 {"error":"Agent not found"}`。

## 根因

`configs/api.yaml`（API 二进制实际加载的配置文件）中没有 `agents:` 段，导致：

1. `bootstrap.Config.Agents.Agents` 为空 map
2. `app.go` 中 `len(bootstrap.Config.Agents.Agents) > 0` 的守卫条件失败
3. `RegisterConfiguredAgents()` 和 `agentFactory.GetOrCreateFromConfig()` 均被跳过
4. v1 runtime.Manager 中无任何 agent 注册
5. `AgentMessage()` handler 调用 `manager.Get("conversation")` 返回 nil → 返回 404

> 注意：`configs/agents.yaml` 虽然定义了 `conversation` agent，但 `LoadAPIConfigWithModel()` 只加载 `api.yaml` + `model.yaml`，**不自动加载 agents.yaml**。

## 修复

在 `configs/api.yaml` 末尾追加 `agents:` 段，注册 `conversation` agent（`type: react`）。

API 启动时 `RegisterConfiguredAgents()` 会在 v1 manager 中注册该 agent，`AgentMessage()` 返回 HTTP 202。

## 验证路径

CI 性能测试流程：
```
POST /api/agents/conversation/message
→ handler.agentManager.Get("conversation") → 找到 ✓
→ createJob()
→ return HTTP 202 with job_id ✓
```